### PR TITLE
Esbuild middleware

### DIFF
--- a/perla.schema.json
+++ b/perla.schema.json
@@ -164,6 +164,14 @@
                     "type": "boolean",
                     "default": true
                 },
+                "jsxFactory": {
+                    "description": "This sets the function that is called for each JSX element.",
+                    "type": "string"
+                },
+                "jsxFragment": {
+                    "description": "This sets the function that is called for each JSX fragment.",
+                    "type": "string"
+                },
                 "externals": {
                     "description": "Third party libraries that you want esbuild to ignore (i.e. bare specifiers), eg. excluding lit from the bundle from \"import { LitElement from 'lit'\" by default perla excludes all of the specifiers that are in the packages map.",
                     "type": "array",

--- a/perla.schema.json
+++ b/perla.schema.json
@@ -181,6 +181,18 @@
                             "@undeclared/dep"
                         ]
                     ]
+                },
+                "injects": {
+                    "description": "A list of files to inject at the transformation phase, i.e import React from 'react' or import { h, Fragment } from 'preact', so you don't have to do it by hand on every file",
+                    "type": "array",
+                    "examples": [
+                        [
+                            "./react-shim.js"
+                        ],
+                        [
+                            "./preact-shim.js"
+                        ]
+                    ]
                 }
             }
         }

--- a/src/App/index.html
+++ b/src/App/index.html
@@ -13,6 +13,7 @@
   </head>
   <body>
     <div id="lit-app"></div>
+    <div id="lit-app-2"></div>
     <div id="fable-app"></div>
     <script data-entry-point src="./src/Main.fs.js" type="module"></script>
   </body>

--- a/src/App/src/file.ts
+++ b/src/App/src/file.ts
@@ -1,0 +1,14 @@
+import { html } from 'lit-html';
+
+
+export function TsSample(value: number, kind: Kind) {
+    return html`
+        <div>
+            <h1>Hello From Typescript!</h1>
+            <p>Vaue: ${value}, Kind: ${kind}</p>
+        </div>
+    `;
+}
+
+
+export type Kind = 'a' | 'b' | 'c';

--- a/src/App/src/lit.js
+++ b/src/App/src/lit.js
@@ -1,8 +1,11 @@
 import { html, render } from 'lit-html';
+import { TsSample } from './file.js';
 
 
 function Sample() {
     return html`<p>hello there!</p>`;
 }
-
-render(Sample(), document.querySelector("#lit-app"));
+const litApp = document.querySelector("#lit-app");
+const litApp2 = document.querySelector("#lit-app-2");
+render(Sample(), litApp);
+render(TsSample(10, 'c'), litApp2);

--- a/src/Perla/Build.fs
+++ b/src/Perla/Build.fs
@@ -169,7 +169,7 @@ module Build =
     let outDir = defaultArg buildConfig.outDir "./dist"
 
     let esbuildVersion =
-      defaultArg buildConfig.esbuildVersion "0.13.1"
+      defaultArg buildConfig.esbuildVersion Constants.Esbuild_Version
 
     task {
       match config.fable with

--- a/src/Perla/Build.fs
+++ b/src/Perla/Build.fs
@@ -226,6 +226,9 @@ module Build =
                      && not <| file.Contains(".fs")
                      && not <| file.Contains(".js")
                      && not <| file.Contains(".css")
+                     && not <| file.Contains(".ts")
+                     && not <| file.Contains(".jsx")
+                     && not <| file.Contains(".tsx")
                      && not <| file.Contains("index.html"))
         }
 

--- a/src/Perla/Commands.fs
+++ b/src/Perla/Commands.fs
@@ -24,6 +24,16 @@ module Commands =
     let autoStartServer = defaultArg deServer.autoStart true
     let autoStartFable = defaultArg fableConfig.autoStart true
 
+    let esbuildVersion =
+      configuration.build
+      |> Option.map (fun build -> build.esbuildVersion)
+      |> Option.flatten
+      |> Option.defaultValue Constants.Esbuild_Version
+
+    Esbuild.setupEsbuild esbuildVersion
+    |> Async.AwaitTask
+    |> Async.StartImmediate
+
     asyncSeq {
       if autoStartServer then "start"
       if autoStartFable then "start:fable"

--- a/src/Perla/Esbuild.fs
+++ b/src/Perla/Esbuild.fs
@@ -87,6 +87,10 @@ let addInjects (injects: string seq option) (args: Builders.ArgumentsBuilder) =
   |> Seq.map (fun inject -> $"--inject:{inject}")
   |> args.Add
 
+let addTsconfigRaw (tsconfig: string option) (args: Builders.ArgumentsBuilder) =
+  match tsconfig with
+  | Some tsconfig -> args.Add $"--tsconfig-raw='{tsconfig}'"
+  | None -> args
 
 let private tgzDownloadPath =
   Path.Combine(Env.getToolsPath (), "esbuild.tgz")
@@ -231,6 +235,7 @@ let private buildSingleFileCmd
   let execBin =
     defaultArg config.esBuildPath esbuildExec
 
+  let tsconfig = Fs.tryGetTsconfigFile ()
   let (strout, strerr) = strio
 
   Cli
@@ -246,6 +251,7 @@ let private buildSingleFileCmd
       |> addJsxFactory config.jsxFactory
       |> addJsxFragment config.jsxFragment
       |> addInlineSourceMaps
+      |> addTsconfigRaw tsconfig
       |> ignore)
     .WithValidation(CommandResultValidation.None)
 

--- a/src/Perla/Esbuild.fs
+++ b/src/Perla/Esbuild.fs
@@ -1,0 +1,223 @@
+﻿module Perla.Esbuild
+
+open System
+open System.IO
+open System.Net.Http
+open System.Threading.Tasks
+
+open ICSharpCode.SharpZipLib.Tar
+open ICSharpCode.SharpZipLib.GZip
+
+open CliWrap
+
+open Types
+open System.Text
+
+type LoaderType =
+  | Typescript
+  | Tsx
+  | Jsx
+
+let addEsExternals
+  (externals: (string seq) option)
+  (args: Builders.ArgumentsBuilder)
+  =
+  let externals = defaultArg externals Seq.empty
+
+  externals
+  |> Seq.map (fun ex -> $"--external:{ex}")
+  |> args.Add
+
+let addIsBundle (isBundle: bool option) (args: Builders.ArgumentsBuilder) =
+  let isBundle = defaultArg isBundle true
+
+  if isBundle then
+    args.Add("--bundle")
+  else
+    args
+
+let addMinify (minify: bool option) (args: Builders.ArgumentsBuilder) =
+  let minify = defaultArg minify true
+
+  if minify then
+    args.Add("--minify")
+  else
+    args
+
+let addFormat (format: string option) (args: Builders.ArgumentsBuilder) =
+  let format = defaultArg format "esm"
+  args.Add $"--format={format}"
+
+let addTarget (target: string option) (args: Builders.ArgumentsBuilder) =
+  let target = defaultArg target "es2015"
+
+  args.Add $"--target={target}"
+
+let addOutDir (outdir: string option) (args: Builders.ArgumentsBuilder) =
+  let outdir = defaultArg outdir "./dist"
+
+  args.Add $"--outdir={outdir}"
+
+let addOutFile (outfile: string) (args: Builders.ArgumentsBuilder) =
+  args.Add $"--outfile={outfile}"
+
+let addLoader (loader: LoaderType) (args: Builders.ArgumentsBuilder) =
+  let loader =
+    match loader with
+    | Typescript -> "ts"
+    | Tsx -> "tsx"
+    | Jsx -> "jsx"
+
+  args.Add $"--loader={loader}"
+
+let addInlineSourceMaps (args: Builders.ArgumentsBuilder) =
+  args.Add "--sourcemap=inline"
+
+
+let private tgzDownloadPath =
+  Path.Combine(Env.getToolsPath (), "esbuild.tgz")
+
+let esbuildExec =
+  let bin = if Env.isWindows then "" else "bin"
+  let exec = if Env.isWindows then ".exe" else ""
+  Path.Combine(Env.getToolsPath (), "package", bin, $"esbuild{exec}")
+
+let private tryDownloadEsBuild (esbuildVersion: string) : Task<string option> =
+  let binString =
+    $"esbuild-{Env.platformString}-{Env.archString}"
+
+  let url =
+    $"https://registry.npmjs.org/{binString}/-/{binString}-{esbuildVersion}.tgz"
+
+  Directory.CreateDirectory(Path.GetDirectoryName(tgzDownloadPath))
+  |> ignore
+
+  task {
+    try
+      use client = new HttpClient()
+      printfn "Downloading esbuild from: %s" url
+
+      use! stream = client.GetStreamAsync(url)
+      use file = File.OpenWrite(tgzDownloadPath)
+
+      do! stream.CopyToAsync file
+      return Some(file.Name)
+    with
+    | ex ->
+      eprintfn "%O" ex
+      return None
+  }
+
+let private chmodBinCmd () =
+  Cli
+    .Wrap("chmod")
+    .WithStandardErrorPipe(PipeTarget.ToStream(Console.OpenStandardError()))
+    .WithStandardOutputPipe(PipeTarget.ToStream(Console.OpenStandardOutput()))
+    .WithArguments($"+x {esbuildExec}")
+
+let private decompressFile (path: Task<string option>) =
+  task {
+    match! path with
+    | Some path ->
+
+      use stream = new GZipInputStream(File.OpenRead path)
+
+      use archive =
+        TarArchive.CreateInputTarArchive(stream, Text.Encoding.UTF8)
+
+      archive.ExtractContents(Path.Combine(Path.GetDirectoryName path))
+
+      if Env.isWindows |> not then
+        printfn $"Executing: chmod +x on \"{esbuildExec}\""
+        let res = chmodBinCmd().ExecuteAsync()
+        do! res.Task :> Task
+
+      return Some path
+    | None -> return None
+  }
+
+let private cleanup (path: Task<string option>) =
+  task {
+    match! path with
+    | Some path -> File.Delete(path)
+    | None -> ()
+  }
+
+let setupEsbuild (esbuildVersion: string) =
+  if not <| File.Exists(esbuildExec) then
+    tryDownloadEsBuild esbuildVersion
+    |> decompressFile
+    |> cleanup
+  else
+    Task.FromResult(())
+
+
+
+let esbuildJsCmd (entryPoint: string) (config: BuildConfig) =
+
+  let dirName =
+    (Path.GetDirectoryName entryPoint)
+      .Split(Path.DirectorySeparatorChar)
+    |> Seq.last
+
+  let outDir =
+    match config.outDir with
+    | Some outdir -> Path.Combine(outdir, dirName) |> Some
+    | None -> Path.Combine("./dist", dirName) |> Some
+
+  let execBin =
+    defaultArg config.esBuildPath esbuildExec
+
+  Cli
+    .Wrap(execBin)
+    .WithStandardErrorPipe(PipeTarget.ToStream(Console.OpenStandardError()))
+    .WithStandardOutputPipe(PipeTarget.ToStream(Console.OpenStandardOutput()))
+    .WithArguments(fun args ->
+      args.Add(entryPoint)
+      |> addEsExternals config.externals
+      |> addIsBundle config.bundle
+      |> addTarget config.target
+      |> addMinify config.minify
+      |> addFormat config.format
+      |> addOutDir outDir
+      |> ignore)
+
+let esbuildCssCmd (entryPoint: string) (config: BuildConfig) =
+  let execBin =
+    defaultArg config.esBuildPath esbuildExec
+
+  Cli
+    .Wrap(execBin)
+    .WithStandardErrorPipe(PipeTarget.ToStream(Console.OpenStandardError()))
+    .WithStandardOutputPipe(PipeTarget.ToStream(Console.OpenStandardOutput()))
+    .WithArguments(fun args ->
+      args.Add(entryPoint)
+      |> addIsBundle config.bundle
+      |> addMinify config.minify
+      |> addOutDir config.outDir
+      |> ignore)
+
+let buildSingleFileCmd
+  (config: BuildConfig)
+  (loader: LoaderType)
+  (stdio: StringBuilder * StringBuilder)
+  (content: string)
+  : Command =
+  let execBin =
+    defaultArg config.esBuildPath esbuildExec
+
+  let (stdout, stderr) = stdio
+
+  Cli
+    .Wrap(execBin)
+    .WithStandardInputPipe(PipeSource.FromString(content))
+    .WithStandardOutputPipe(PipeTarget.ToStringBuilder(stdout))
+    .WithStandardErrorPipe(PipeTarget.ToStringBuilder(stderr))
+    .WithArguments(fun args ->
+      args
+      |> addTarget config.target
+      |> addLoader loader
+      |> addFormat ("esm" |> Some)
+      |> addInlineSourceMaps
+      |> ignore)
+    .WithValidation(CommandResultValidation.None)

--- a/src/Perla/Esbuild.fs
+++ b/src/Perla/Esbuild.fs
@@ -67,6 +67,16 @@ let addLoader (loader: LoaderType) (args: Builders.ArgumentsBuilder) =
 
   args.Add $"--loader={loader}"
 
+let addJsxFactory (factory: string option) (args: Builders.ArgumentsBuilder) =
+  match factory with
+  | Some factory -> args.Add $"--jsx-factory={factory}"
+  | None -> args
+
+let addJsxFragment (fragment: string option) (args: Builders.ArgumentsBuilder) =
+  match fragment with
+  | Some fragment -> args.Add $"--jsx-fragment={fragment}"
+  | None -> args
+
 let addInlineSourceMaps (args: Builders.ArgumentsBuilder) =
   args.Add "--sourcemap=inline"
 
@@ -225,6 +235,8 @@ let private buildSingleFileCmd
       |> addTarget config.target
       |> addLoader loader
       |> addFormat ("esm" |> Some)
+      |> addJsxFactory config.jsxFactory
+      |> addJsxFragment config.jsxFragment
       |> addInlineSourceMaps
       |> ignore)
     .WithValidation(CommandResultValidation.None)

--- a/src/Perla/IO.fs
+++ b/src/Perla/IO.fs
@@ -338,7 +338,14 @@ module Fs =
              fsw.NotifyFilter <- NotifyFilters.FileName ||| NotifyFilters.Size
 
              let filters =
-               defaultArg config.extensions (Seq.ofList [ "*.js"; "*.css" ])
+               defaultArg
+                 config.extensions
+                 (Seq.ofList [ "*.js"
+                               "*.css"
+                               "*.ts"
+                               "*.tsx"
+                               "*.jsx"
+                               "*.json" ])
 
              for filter in filters do
                fsw.Filters.Add(filter)

--- a/src/Perla/IO.fs
+++ b/src/Perla/IO.fs
@@ -326,6 +326,8 @@ module Fs =
       | ex -> return! ex |> Error
     }
 
+  let compileErrWatcher = lazy (Subject.behavior "")
+
   let getFileWatcher (config: WatchConfig) =
     let watchers =
       (defaultArg config.directories ([ "./src" ] |> Seq.ofList))

--- a/src/Perla/IO.fs
+++ b/src/Perla/IO.fs
@@ -433,3 +433,9 @@ module Fs =
     tryReadFileWithExtension fileNoExt Typescript
     |> TaskResult.orElseWith (fun _ -> tryReadFileWithExtension fileNoExt Jsx)
     |> TaskResult.orElseWith (fun _ -> tryReadFileWithExtension fileNoExt Tsx)
+
+  let tryGetTsconfigFile () =
+    try
+      File.ReadAllText("./tsconfig.json") |> Some
+    with
+    | _ -> None

--- a/src/Perla/IO.fs
+++ b/src/Perla/IO.fs
@@ -326,7 +326,13 @@ module Fs =
       | ex -> return! ex |> Error
     }
 
-  let compileErrWatcher = lazy (Subject.behavior "")
+  let CompileErrWatcherEvent = lazy (new Event<string>())
+
+  let PublishCompileErr err =
+    CompileErrWatcherEvent.Value.Trigger err
+
+  let compileErrWatcher () = CompileErrWatcherEvent.Value.Publish
+
 
   let getFileWatcher (config: WatchConfig) =
     let watchers =

--- a/src/Perla/Perla.fsproj
+++ b/src/Perla/Perla.fsproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Compile Include="Types.fs" />
     <Compile Include="IO.fs" />
+    <Compile Include="Esbuild.fs" />
     <Compile Include="Fable.fs" />
     <Compile Include="Server.fs" />
     <Compile Include="Build.fs" />

--- a/src/Perla/Server.fs
+++ b/src/Perla/Server.fs
@@ -149,6 +149,9 @@ document.head.appendChild(style)"""
         ctx.SetContentType "text/javascript"
 
         try
+          if Path.GetExtension(filePath) <> ".js" then
+            return failwith "Not a JS file, Try looking with another extension."
+
           let! content = File.ReadAllBytesAsync(filePath)
           do! ctx.WriteBytesAsync content :> Task
         with

--- a/src/Perla/Types.fs
+++ b/src/Perla/Types.fs
@@ -25,6 +25,11 @@ module Types =
     | "stop" -> Exit
     | value -> Unknown value
 
+  type LoaderType =
+    | Typescript
+    | Tsx
+    | Jsx
+
   type FableConfig =
     { autoStart: bool option
       project: string option

--- a/src/Perla/Types.fs
+++ b/src/Perla/Types.fs
@@ -42,7 +42,15 @@ module Types =
       directories: string seq option }
 
     static member Default() =
-      { extensions = [ "*.js"; "*.css" ] |> List.toSeq |> Some
+      { extensions =
+          [ "*.js"
+            "*.css"
+            "*.ts"
+            "*.tsx"
+            "*.jsx"
+            "*.json" ]
+          |> List.toSeq
+          |> Some
         directories = [ "./src" ] |> List.toSeq |> Some }
 
   type DevServerConfig =

--- a/src/Perla/Types.fs
+++ b/src/Perla/Types.fs
@@ -3,7 +3,11 @@
 open System
 open System.Text.Json
 open System.Text.Json.Serialization
-open System.Collections.Generic
+
+
+module Constants =
+  [<Literal>]
+  let Esbuild_Version = "0.13.2"
 
 module Types =
 
@@ -89,7 +93,7 @@ module Types =
 
     static member DefaultConfig() =
       { esBuildPath = None
-        esbuildVersion = Some "0.13.2"
+        esbuildVersion = Some Constants.Esbuild_Version
         target = Some "es2017"
         outDir = None
         bundle = Some true

--- a/src/Perla/Types.fs
+++ b/src/Perla/Types.fs
@@ -90,6 +90,7 @@ module Types =
       minify: bool option
       jsxFactory: string option
       jsxFragment: string option
+      injects: (string seq) option
       externals: (string seq) option }
 
 
@@ -103,6 +104,7 @@ module Types =
         minify = Some true
         jsxFactory = None
         jsxFragment = None
+        injects = None
         externals = None }
 
   type FdsConfig =

--- a/src/Perla/Types.fs
+++ b/src/Perla/Types.fs
@@ -88,6 +88,8 @@ module Types =
       bundle: bool option
       format: string option
       minify: bool option
+      jsxFactory: string option
+      jsxFragment: string option
       externals: (string seq) option }
 
 
@@ -99,6 +101,8 @@ module Types =
         bundle = Some true
         format = Some "esm"
         minify = Some true
+        jsxFactory = None
+        jsxFragment = None
         externals = None }
 
   type FdsConfig =

--- a/src/Perla/livereload.js
+++ b/src/Perla/livereload.js
@@ -15,12 +15,18 @@ function replaceCssContent({ oldName, name, content }) {
     style.setAttribute("filename", name);
 }
 
+function showOverlay({ error }) {
+    console.log('show overlay');
+}
+
 worker.addEventListener("message", function({ data }) {
     switch (data?.event) {
         case "reload":
             return window.location.reload();
         case "replace-css":
             return replaceCssContent(data);
+        case "compile-err":
+            return showOverlay(data);
         default:
             return console.log('Unknown message:', data);
     }

--- a/src/Perla/worker.js
+++ b/src/Perla/worker.js
@@ -1,4 +1,4 @@
-﻿self.addEventListener('connect', function (e) {
+﻿self.addEventListener('connect', function(e) {
     console.log('connected');
 });
 
@@ -15,17 +15,17 @@ const tryParse = string => {
 function connectToSource() {
     if (source) return;
     source = new EventSource("/~perla~/sse");
-    source.addEventListener("open", function (event) {
+    source.addEventListener("open", function(event) {
         console.log("Connected");
     });
 
-    source.addEventListener("reload", function (event) {
+    source.addEventListener("reload", function(event) {
         console.log("Reloading, file changed: ", event.data);
         self.postMessage({
             event: 'reload'
         });
     });
-    source.addEventListener("replace-css", function (event) {
+    source.addEventListener("replace-css", function(event) {
         const {
             oldName,
             name,
@@ -37,10 +37,19 @@ function connectToSource() {
             name,
             content
         });
-    })
+    });
+
+    source.addEventListener("compile-err", function(event) {
+        const { error } = tryParse(event.data);
+        console.error(error);
+        self.postMessage({
+            event: 'compile-err',
+            error
+        });
+    });
 }
 
-self.addEventListener('message', function ({ data }) {
+self.addEventListener('message', function({ data }) {
     if (data?.event === 'connect') {
         connectToSource();
     }


### PR DESCRIPTION
This Fixes #14 there are rough edges and we're still missing some things

- [x] JSX/TSX build options `--jsx-factory=h  --jsx-fragment=Fragment`
    - [x] perla schema
    - [x] build config
- [x] Fix overlay report (currently the server keeps all errors in a behavior subject so once you re-subscribe it picks everything again
- [x] Ensure ts/jsx/tsx files don't get copied to the dist folder the at build time
- [x] Ensure that esbuild is downloaded and present before starting the dev server rather than checking it when requesting a particular file