### PR TITLE
add list subcommand

### DIFF
--- a/src/Perla/Commands.fs
+++ b/src/Perla/Commands.fs
@@ -1,6 +1,7 @@
 ﻿namespace Perla
 
 open System
+open System.Text.Json
 open FSharp.Control
 open FsToolkit.ErrorHandling
 
@@ -111,6 +112,19 @@ type AddArgs =
       | Source _ ->
         "The name of the source you want to install a package from. e.g. unpkg or skypack."
 
+type ListArgs =
+  | As_Package_Json
+
+  static member ToOptions(args: ParseResults<ListArgs>) : ListPackagesOptions =
+    match args.TryGetResult(As_Package_Json) with
+    | Some _ -> { format = PackageJson }
+    | _ -> { format = HumanReadable }
+
+  interface IArgParserTemplate with
+    member this.Usage: string =
+      match this with
+      | As_Package_Json -> "List packages in npm's package.json format."
+
 type DevServerArgs =
   | [<CliPrefix(CliPrefix.None); AltCommandLine("s")>] Serve of
     ParseResults<ServerArgs>
@@ -122,6 +136,7 @@ type DevServerArgs =
   | [<CliPrefix(CliPrefix.None)>] Show of ParseResults<ShowArgs>
   | [<CliPrefix(CliPrefix.None)>] Add of ParseResults<AddArgs>
   | [<CliPrefix(CliPrefix.None)>] Remove of ParseResults<RemoveArgs>
+  | [<CliPrefix(CliPrefix.None)>] List of ParseResults<ListArgs>
   | [<AltCommandLine("-v")>] Version
 
   interface IArgParserTemplate with
@@ -135,6 +150,7 @@ type DevServerArgs =
       | Show _ -> "Gets the skypack information about a package."
       | Add _ -> "Generates an entry in the import map."
       | Remove _ -> "Removes an entry in the import map."
+      | List _ -> "List entries in the import map."
       | Version _ -> "Prints out the cli version to the console."
 
 module Commands =
@@ -328,6 +344,51 @@ Updated: {package.updatedAt.ToShortDateString()}"""
       return 0
     }
 
+  let runList (options: ListPackagesOptions) =
+    let (|ParseRegex|_|) regex str =
+      let m =
+        Text.RegularExpressions.Regex(regex).Match(str)
+
+      if m.Success then
+        Some(List.tail [ for x in m.Groups -> x.Value ])
+      else
+        None
+
+    taskResult {
+      let! lockFile = Fs.getorCreateLockFile (GetFdsConfigPath())
+
+      let parseUrl url =
+        match url with
+        | ParseRegex @"https://cdn.skypack.dev/pin/(@?[^@]+)@v([\d.]+)"
+                     [ name; version ]
+        | ParseRegex @"https://cdn.jsdelivr.net/npm/(@?[^@]+)@([\d.]+)"
+                     [ name; version ]
+        | ParseRegex @"https://ga.jspm.io/npm:(@?[^@]+)@([\d.]+)"
+                     [ name; version ]
+        | ParseRegex @"https://unpkg.com/(@?[^@]+)@([\d.]+)" [ name; version ] ->
+          Some(name, version)
+        | _ -> None
+
+      match options.format with
+      | HumanReadable ->
+        printfn "Installed packages (alias: packageName@version)"
+        printfn ""
+        for importMap in lockFile.imports do
+          match parseUrl importMap.Value with
+          | Some (name, version) -> printfn $"{importMap.Key}: {name}@{version}"
+          | None -> printfn $"{importMap.Key}: Couldn't parse {importMap.Value}"
+      | PackageJson ->
+        let dependencies =
+          lockFile.imports
+          |> Map.toList
+          |> List.choose (fun (_alias, importMap) -> parseUrl importMap)
+          |> Map.ofList
+
+        JsonSerializer.Serialize({| dependencies = dependencies |}, JsonSerializerOptions(WriteIndented=true))
+        |> printfn "%s"
+      return 0
+    }
+
   let runRemove (options: RemovePackageOptions) =
     taskResult {
       let name = defaultArg options.package ""
@@ -463,8 +524,15 @@ Updated: {package.updatedAt.ToShortDateString()}"""
           |> runShow
           |> Async.AwaitTask
           |> Async.Ignore
+      | Some (List subcmd) ->
+        return!
+          subcmd
+          |> ListArgs.ToOptions
+          |> runList
+          |> Async.AwaitTask
+          |> Async.Ignore
       | err ->
-        parsed.Raise("No Commands Specified", showUsage = true)
+        parsed.Raise($"Hello Commands Specified {err}", showUsage = true)
         return! CommandNotParsedException $"%A{err}" |> Error
     }
 

--- a/src/Perla/IO.fs
+++ b/src/Perla/IO.fs
@@ -69,6 +69,9 @@ module internal Json =
     opts.WriteIndented <- false
     JsonSerializer.Serialize(value, opts)
 
+  let ToPackageJson dependencies =
+    JsonSerializer.Serialize({| dependencies = dependencies |}, jsonOptions ())
+
 [<RequireQualifiedAccessAttribute>]
 module internal Http =
   open Flurl

--- a/src/Perla/Program.fs
+++ b/src/Perla/Program.fs
@@ -73,6 +73,8 @@ let main argv =
             |> Commands.runSearch
         | Some (Show subcmd) ->
           return! subcmd |> ShowArgs.ToOptions |> Commands.runShow
+        | Some (List subcmd) ->
+          return! subcmd |> ListArgs.ToOptions |> Commands.runList
         | err ->
           parsed.Raise("No Commands Specified", showUsage = true)
           return! CommandNotParsedException $"%A{err}" |> Error

--- a/src/Perla/Types.fs
+++ b/src/Perla/Types.fs
@@ -250,6 +250,10 @@ module Types =
 
   type RemovePackageOptions = { package: string option }
 
+  type ListFormat = HumanReadable | PackageJson
+
+  type ListPackagesOptions = { format: ListFormat }
+
   exception CommandNotParsedException of string
   exception HelpRequestedException
   exception MissingPackageNameException


### PR DESCRIPTION
Adding list subcommand to perla cli.
The idea is to use it in femto for version resolution but to be independent of perla.jsonc.lock file format.

 