### PR TITLE
search for perla config file in parent directories

### DIFF
--- a/src/Perla/Commands.fs
+++ b/src/Perla/Commands.fs
@@ -472,13 +472,13 @@ Updated: {package.updatedAt.ToShortDateString()}"""
     let onStdinAsync =
       serverActions tryExecPerlaCommand configuration
 
-    let deServer =
+    let devServer =
       defaultArg configuration.devServer (DevServerConfig.DefaultConfig())
 
     let fableConfig =
       defaultArg configuration.fable (FableConfig.DefaultConfig())
 
-    let autoStartServer = defaultArg deServer.autoStart true
+    let autoStartServer = defaultArg devServer.autoStart true
     let autoStartFable = defaultArg fableConfig.autoStart true
 
     let esbuildVersion =

--- a/src/Perla/IO.fs
+++ b/src/Perla/IO.fs
@@ -256,6 +256,11 @@ module Fs =
       findConfigFile (Path.GetFullPath workDir)
       |> Option.defaultValue (Path.Combine(workDir, FdsConfigName))
 
+    static member SetCurrentDirectoryToFdsConfigDirectory() =
+      Paths.GetFdsConfigPath()
+      |> Path.GetDirectoryName
+      |> Directory.SetCurrentDirectory
+
   let getFdsConfig filepath =
     try
       let bytes = File.ReadAllBytes filepath

--- a/src/Perla/IO.fs
+++ b/src/Perla/IO.fs
@@ -241,7 +241,20 @@ module Fs =
 
   type Paths() =
     static member GetFdsConfigPath(?path: string) =
-      $"{defaultArg path (Environment.CurrentDirectory)}/{FdsConfigName}"
+      let rec findConfigFile currDir =
+        let path = Path.Combine (currDir, FdsConfigName)
+        if File.Exists path then
+          Some path
+        else
+          let parent = Path.GetDirectoryName currDir
+          if parent <> currDir then
+            findConfigFile parent
+          else
+            None
+
+      let workDir = defaultArg path Environment.CurrentDirectory
+      findConfigFile (Path.GetFullPath workDir)
+      |> Option.defaultValue (Path.Combine(workDir, FdsConfigName))
 
   let getFdsConfig filepath =
     try

--- a/src/Perla/Program.fs
+++ b/src/Perla/Program.fs
@@ -48,12 +48,14 @@ let main argv =
           let buildConfig =
             Commands.getBuildOptions (items.GetAllResults())
 
+          Fs.Paths.SetCurrentDirectoryToFdsConfigDirectory()
           do! Commands.startBuild buildConfig :> Task
           return! Ok 0
         | Some (Serve items) ->
           let serverConfig =
             Commands.getServerOptions (items.GetAllResults())
 
+          Fs.Paths.SetCurrentDirectoryToFdsConfigDirectory()
           do! Commands.startInteractive serverConfig
 
           return! Ok 0


### PR DESCRIPTION
Added searching for perla.jsonc in parent directories so that it is easier to add/remove packages if current directory is some subdirectory.