### PR TITLE
Fix various typos

### DIFF
--- a/src/Perla/Build.fs
+++ b/src/Perla/Build.fs
@@ -84,7 +84,7 @@ module Build =
     script.SetAttribute("type", "importmap")
 
     task {
-      match! Fs.getorCreateLockFile (Fs.Paths.GetPerlaConfigPath()) with
+      match! Fs.getOrCreateLockFile (Fs.Paths.GetPerlaConfigPath()) with
       | Ok lock ->
         let map: ImportMap =
           { imports = lock.imports
@@ -132,7 +132,7 @@ module Build =
 
   let getExcludes config =
     task {
-      match! Fs.getorCreateLockFile (Fs.Paths.GetPerlaConfigPath()) with
+      match! Fs.getOrCreateLockFile (Fs.Paths.GetPerlaConfigPath()) with
       | Ok lock ->
         let excludes =
           lock.imports

--- a/src/Perla/Commands.fs
+++ b/src/Perla/Commands.fs
@@ -401,7 +401,7 @@ Updated: {package.updatedAt.ToShortDateString()}"""
         return! PackageNotFoundException |> Error
 
       let! fdsConfig = Fs.getPerlaConfig (GetPerlaConfigPath())
-      let! lockFile = Fs.getorCreateLockFile (GetPerlaConfigPath())
+      let! lockFile = Fs.getOrCreateLockFile (GetPerlaConfigPath())
 
       let deps =
         fdsConfig.packages
@@ -447,7 +447,7 @@ Updated: {package.updatedAt.ToShortDateString()}"""
         Http.getPackageUrlInfo $"{package}{version}" alias source
 
       let! fdsConfig = Fs.getPerlaConfig (GetPerlaConfigPath())
-      let! lockFile = Fs.getorCreateLockFile (GetPerlaConfigPath())
+      let! lockFile = Fs.getOrCreateLockFile (GetPerlaConfigPath())
 
       let packages =
         fdsConfig.packages

--- a/src/Perla/Commands.fs
+++ b/src/Perla/Commands.fs
@@ -149,7 +149,7 @@ type DevServerArgs =
       | Show _ -> "Gets the skypack information about a package."
       | Add _ -> "Generates an entry in the import map."
       | Remove _ -> "Removes an entry in the import map."
-      | List _ -> "List entries in the import map."
+      | List _ -> "Lists entries in the import map."
       | Version _ -> "Prints out the cli version to the console."
 
 module Commands =
@@ -533,7 +533,7 @@ Updated: {package.updatedAt.ToShortDateString()}"""
           |> Async.AwaitTask
           |> Async.Ignore
       | err ->
-        parser.PrintUsage("No Commands Specified", hideSyntax = true)
+        parser.PrintUsage("No command specified", hideSyntax = true)
         |> printfn "%s"
 
         return! async { return () }

--- a/src/Perla/Commands.fs
+++ b/src/Perla/Commands.fs
@@ -22,7 +22,7 @@ type ServerArgs =
   interface IArgParserTemplate with
     member this.Usage =
       match this with
-      | Port _ -> "Select the server port, defaults to 7331"
+      | Port _ -> "Selects the server port, defaults to 7331"
       | Host _ -> "Server host, defaults to localhost"
       | Use_Ssl _ -> "Forces the requests to go through HTTPS. Defaults to true"
       | Auto_Start _ -> "Starts the server without action required by the user."
@@ -37,7 +37,7 @@ type BuildArgs =
       | Index_File _ ->
         "The Entry File for the web application. Defaults to \"index.html\""
       | Esbuild_Version _ ->
-        "Use a specific esbuild version. defaults to \"0.12.9\""
+        "Uses a specific esbuild version. defaults to \"0.12.9\""
       | Out_Dir _ -> "Where to output the files. Defaults to \"./dist\""
 
 type InitArgs =
@@ -52,7 +52,7 @@ type InitArgs =
     member this.Usage: string =
       match this with
       | Path _ -> "Where to write the config file"
-      | With_Fable _ -> "Include fable options in the config file"
+      | With_Fable _ -> "Includes fable options in the config file"
 
 type SearchArgs =
   | [<AltCommandLine("-n")>] Name of string
@@ -122,7 +122,7 @@ type ListArgs =
   interface IArgParserTemplate with
     member this.Usage: string =
       match this with
-      | As_Package_Json -> "List packages in npm's package.json format."
+      | As_Package_Json -> "Lists packages in npm's package.json format."
 
 type DevServerArgs =
   | [<CliPrefix(CliPrefix.None); AltCommandLine("s")>] Serve of

--- a/src/Perla/Commands.fs
+++ b/src/Perla/Commands.fs
@@ -90,8 +90,7 @@ type RemoveArgs =
   interface IArgParserTemplate with
     member this.Usage: string =
       match this with
-      | Package _ ->
-        "The name of the package to remove from the import map this can also be aliased name."
+      | Package _ -> "Package name (or alias) to remove from the import map."
 
 type AddArgs =
   | [<AltCommandLine("-p")>] Package of string

--- a/src/Perla/Esbuild.fs
+++ b/src/Perla/Esbuild.fs
@@ -182,7 +182,7 @@ let private cleanup (path: Task<string option>) =
   }
 
 let setupEsbuild (esbuildVersion: string) =
-  printfn "Checking esbuild is present..."
+  printfn "Checking whether esbuild is present..."
 
   if not <| File.Exists(esbuildExec) then
     printfn "esbuild is not present, setting esbuild..."
@@ -305,7 +305,7 @@ let tryCompileFile filepath config =
           $"{injects}\n{strout}"
         with
         | ex ->
-          printfn $"Perla Serve: Failed to inject, {ex.Message}"
+          printfn $"Perla Serve: failed to inject, {ex.Message}"
           strout
       | _ -> strout
 

--- a/src/Perla/Fable.fs
+++ b/src/Perla/Fable.fs
@@ -14,7 +14,7 @@ module Fable =
 
       activeProcess.Kill()
     with
-    | ex -> printfn $"Failed to Kill Procees with PID: [{pid}]\n{ex.Message}"
+    | ex -> printfn $"Failed to kill process with PID: [{pid}]\n{ex.Message}"
 
   let private addOutDir
     (outdir: string option)

--- a/src/Perla/IO.fs
+++ b/src/Perla/IO.fs
@@ -301,7 +301,7 @@ module Fs =
     with
     | ex -> Error ex
 
-  let getorCreateLockFile configPath =
+  let getOrCreateLockFile configPath =
     taskResult {
       try
         let path = Path.GetFullPath($"%s{configPath}.lock")

--- a/src/Perla/IO.fs
+++ b/src/Perla/IO.fs
@@ -143,7 +143,7 @@ module internal Http =
             | Source.Unpkg -> "unpkg"
             | _ ->
               printfn
-                $"Warn: An unknown provider has been specied: [{source}] defaulting to jspm"
+                $"Warn: an unknown provider has been specified: [{source}] defaulting to jspm"
 
               "jspm" |}
 

--- a/src/Perla/Server.fs
+++ b/src/Perla/Server.fs
@@ -469,7 +469,7 @@ module Server =
             $"https://{customHost}:{customPort + 1}"
           | true ->
             printfn
-              $"Address {customHost}:{customPort} is Busy, selecting a dynamic port."
+              $"Address {customHost}:{customPort} is busy, selecting a dynamic port."
 
             $"http://{customHost}:{0}", $"https://{customHost}:{0}"
 

--- a/src/Perla/Server.fs
+++ b/src/Perla/Server.fs
@@ -368,7 +368,7 @@ module Server =
         liveReload.SetAttribute("type", "text/javascript")
         liveReload.SetAttribute("src", "/~perla~/livereload.js")
 
-        match! Fs.getorCreateLockFile (Fs.Paths.GetPerlaConfigPath()) with
+        match! Fs.getOrCreateLockFile (Fs.Paths.GetPerlaConfigPath()) with
         | Ok lock ->
           let map: ImportMap =
             { imports = lock.imports


### PR DESCRIPTION
I spent some time looking around to see how things are put together, and I fixed some minor things along the way...

Things I saw that I didn't fix:
- there are still several mentions of `fds` in the code that should probably be renamed to `Perla`
- I resisted the urge to change all the `IArgParserTemplate` messages either to imperative (`Do xxx`) or present (`Does ...`). I'm not sure which one you prefer but it would probably be nicer to stay consistent.
- There is a usage message (`"The name of the package to remove from the import map this can also be aliased name."`) that looks like it should be two separate sentences.