### PR TITLE
Add Hellang.Middleware.SpaFallback.

### DIFF
--- a/src/App/src/file.ts
+++ b/src/App/src/file.ts
@@ -5,6 +5,7 @@ export function TsSample(value: number, kind: Kind) {
     return html`
         <div>
             <h1>Hello From Typescript!</h1>
+            <p>The path is ${location.pathname}</p>
             <p>Vaue: ${value}, Kind: ${kind}</p>
         </div>
     `;

--- a/src/Perla/Perla.fsproj
+++ b/src/Perla/Perla.fsproj
@@ -37,6 +37,7 @@
     <PackageReference Include="CliWrap" Version="3.3.3" />
     <PackageReference Include="FSharp.Control.AsyncSeq" Version="3.2.1" />
     <PackageReference Include="FSharp.Control.Reactive" Version="5.0.2" />
+    <PackageReference Include="Hellang.Middleware.SpaFallback" Version="2.0.0" />
     <PackageReference Include="Saturn" Version="0.15.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="Flurl.Http" Version="3.2.0" />

--- a/src/Perla/Server.fs
+++ b/src/Perla/Server.fs
@@ -33,6 +33,8 @@ open Giraffe
 open Saturn
 open Saturn.Endpoint.Router
 
+open Hellang.Middleware.SpaFallback
+
 open CliWrap
 
 open Types
@@ -450,7 +452,7 @@ module Server =
         if liveReload then
           router {
             get "/" Index
-            get "index.html" (redirectTo false "/")
+            get "index.html" Index
             get "/~perla~/sse" (Sse watchConfig)
             get "/~perla~/livereload.js" (sendScript LiveReload)
             get "/~perla~/worker.js" (sendScript Worker)
@@ -458,7 +460,7 @@ module Server =
         else
           router {
             get "/" Index
-            get "index.html" (redirectTo false "/")
+            get "index.html" Index
           }
 
       let withWebhostConfig (config: IWebHostBuilder) =
@@ -482,6 +484,8 @@ module Server =
         if useSSL then
           appConfig.UseHsts().UseHttpsRedirection()
           |> ignore
+
+        appConfig.UseSpaFallback() |> ignore
 
         let ignoreStatic =
           [ ".js"
@@ -534,6 +538,8 @@ module Server =
         (proxyConfig: Map<string, string> option)
         (services: IServiceCollection)
         =
+        services.AddSpaFallback() |> ignore
+
         match proxyConfig with
         | Some _ -> services.AddHttpForwarder()
         | None -> services


### PR DESCRIPTION
By default, this added middleware will serve the `index.html` page.
To not lose the current page URL, I've removed the redirect in the router.
Worked on my machine, flies away now.

Fixes #43.