### PR TITLE
Drop Saturn in favor of Minimal APIs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: Build main
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main]
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -18,4 +22,4 @@ jobs:
       - name: Install local tools
         run: dotnet tool restore
       - name: Build
-        run: dotnet fsi ./build.fsx -t BuildBinaries
+        run: dotnet fsi ./build.fsx -t SimpleBuild

--- a/build.fsx
+++ b/build.fsx
@@ -100,6 +100,14 @@ Target.create "Zip" (fun _ ->
 
 Target.create "Default" (fun _ -> Target.runSimple "Zip" [] |> ignore)
 
+Target.create "SimpleBuild" (fun _ ->
+    DotNet.build
+        (fun opts ->
+            { opts with
+                Configuration = DotNet.BuildConfiguration.Release
+                Framework = Some "net6.0" })
+        "src/Perla/Perla.fsproj")
+
 "Clean"
 ==> "CheckFormat"
 ==> "BuildBinaries"

--- a/build.fsx
+++ b/build.fsx
@@ -28,8 +28,10 @@ let output = "./dist"
 let runtimes =
     [| "linux-x64"
        "linux-arm64"
+       "osx-x64"
+       "osx-arm64"
        "win10-x64"
-       "osx-x64" |]
+       "win10-arm64" |]
 
 let fsharpSourceFiles =
     !! "src/**/*.fs"

--- a/src/Perla.Lib/Esbuild.fs
+++ b/src/Perla.Lib/Esbuild.fs
@@ -64,9 +64,9 @@ module Esbuild =
   let addLoader (loader: LoaderType) (args: Builders.ArgumentsBuilder) =
     let loader =
       match loader with
-      | Typescript -> "ts"
-      | Tsx -> "tsx"
-      | Jsx -> "jsx"
+      | LoaderType.Typescript -> "ts"
+      | LoaderType.Tsx -> "tsx"
+      | LoaderType.Jsx -> "jsx"
 
     args.Add $"--loader={loader}"
 
@@ -311,8 +311,8 @@ module Esbuild =
 
       let strout =
         match loader with
-        | Jsx
-        | Tsx ->
+        | LoaderType.Jsx
+        | LoaderType.Tsx ->
           try
             let injects =
               defaultArg config.injects (Seq.empty)

--- a/src/Perla.Lib/Extensions.fs
+++ b/src/Perla.Lib/Extensions.fs
@@ -5,6 +5,115 @@ module Perla.Lib.Extensions
 open System
 open System.Diagnostics
 open System.IO
+open System.Runtime.CompilerServices
+open System.Text
+open Microsoft.AspNetCore.Http
+open Microsoft.Extensions.Logging
+open Microsoft.Extensions.Primitives
+open Microsoft.Net.Http.Headers
+
+/// Taken from https://github.com/giraffe-fsharp/Giraffe/blob/71ef664f7a6276b1f7cc548189c54dccf633898c/src/Giraffe/HttpContextExtensions.fs#L21
+/// Licensed under: https://github.com/giraffe-fsharp/Giraffe/blob/71ef664f7a6276b1f7cc548189c54dccf633898c/LICENSE
+[<Extension>]
+type HttpContextExtensions() =
+
+  /// <summary>
+  /// Gets an instance of `'T` from the request's service container.
+  /// </summary>
+  /// <returns>Returns an instance of `'T`.</returns>
+  [<Extension>]
+  static member GetService<'T>(ctx: HttpContext) =
+    let t = typeof<'T>
+
+    match ctx.RequestServices.GetService t with
+    | null -> raise (exn t.Name)
+    | service -> service :?> 'T
+
+  /// <summary>
+  /// Gets an instance of <see cref="Microsoft.Extensions.Logging.ILogger{T}" /> from the request's service container.
+  ///
+  /// The type `'T` should represent the class or module from where the logger gets instantiated.
+  /// </summary>
+  /// <returns> Returns an instance of <see cref="Microsoft.Extensions.Logging.ILogger{T}" />.</returns>
+  [<Extension>]
+  static member GetLogger<'T>(ctx: HttpContext) = ctx.GetService<ILogger<'T>>()
+
+  /// <summary>
+  /// Gets an instance of <see cref="Microsoft.Extensions.Logging.ILogger"/> from the request's service container.
+  /// </summary>
+  /// <param name="ctx">The current http context object.</param>
+  /// <param name="categoryName">The category name for messages produced by this logger.</param>
+  /// <returns>Returns an instance of <see cref="Microsoft.Extensions.Logging.ILogger"/>.</returns>
+  [<Extension>]
+  static member GetLogger(ctx: HttpContext, categoryName: string) =
+    let loggerFactory = ctx.GetService<ILoggerFactory>()
+    loggerFactory.CreateLogger categoryName
+
+  /// <summary>
+  /// Sets the HTTP status code of the response.
+  /// </summary>
+  /// <param name="ctx">The current http context object.</param>
+  /// <param name="httpStatusCode">The status code to be set in the response. For convenience you can use the static <see cref="Microsoft.AspNetCore.Http.StatusCodes"/> class for passing in named status codes instead of using pure int values.</param>
+  [<Extension>]
+  static member SetStatusCode(ctx: HttpContext, httpStatusCode: int) =
+    ctx.Response.StatusCode <- httpStatusCode
+
+  /// <summary>
+  /// Adds or sets a HTTP header in the response.
+  /// </summary>
+  /// <param name="ctx">The current http context object.</param>
+  /// <param name="key">The HTTP header name. For convenience you can use the static <see cref="Microsoft.Net.Http.Headers.HeaderNames"/> class for passing in strongly typed header names instead of using pure `string` values.</param>
+  /// <param name="value">The value to be set. Non string values will be converted to a string using the object's ToString() method.</param>
+  [<Extension>]
+  static member SetHttpHeader(ctx: HttpContext, key: string, value: obj) =
+    ctx.Response.Headers.[key] <- StringValues(value.ToString())
+
+  /// <summary>
+  /// Sets the Content-Type HTTP header in the response.
+  /// </summary>
+  /// <param name="ctx">The current http context object.</param>
+  /// <param name="contentType">The mime type of the response (e.g.: application/json or text/html).</param>
+  [<Extension>]
+  static member SetContentType(ctx: HttpContext, contentType: string) =
+    ctx.SetHttpHeader(HeaderNames.ContentType, contentType)
+
+  /// <summary>
+  /// Writes a byte array to the body of the HTTP response and sets the HTTP Content-Length header accordingly.
+  /// </summary>
+  /// <param name="ctx">The current http context object.</param>
+  /// <param name="bytes">The byte array to be send back to the client.</param>
+  /// <returns>Task of Some HttpContext after writing to the body of the response.</returns>
+  [<Extension>]
+  static member WriteBytesAsync(ctx: HttpContext, bytes: byte []) =
+    task {
+      ctx.SetHttpHeader(HeaderNames.ContentLength, bytes.Length)
+
+      if ctx.Request.Method <> HttpMethods.Head then
+        do! ctx.Response.Body.WriteAsync(bytes, 0, bytes.Length)
+
+      return Some ctx
+    }
+
+  /// <summary>
+  /// Writes an UTF-8 encoded string to the body of the HTTP response and sets the HTTP Content-Length header accordingly.
+  /// </summary>
+  /// <param name="ctx">The current http context object.</param>
+  /// <param name="str">The string value to be send back to the client.</param>
+  /// <returns>Task of Some HttpContext after writing to the body of the response.</returns>
+  [<Extension>]
+  static member WriteStringAsync(ctx: HttpContext, str: string) =
+    ctx.WriteBytesAsync(Encoding.UTF8.GetBytes str)
+
+  /// <summary>
+  /// Writes an UTF-8 encoded string to the body of the HTTP response and sets the HTTP `Content-Length` header accordingly, as well as the `Content-Type` header to `text/plain`.
+  /// </summary>
+  /// <param name="ctx">The current http context object.</param>
+  /// <param name="str">The string value to be send back to the client.</param>
+  /// <returns>Task of Some HttpContext after writing to the body of the response.</returns>
+  [<Extension>]
+  static member WriteTextAsync(ctx: HttpContext, str: string) =
+    ctx.SetContentType "text/plain; charset=utf-8"
+    ctx.WriteStringAsync str
 
 module Constants =
   [<Literal>]

--- a/src/Perla.Lib/IO.fs
+++ b/src/Perla.Lib/IO.fs
@@ -2,6 +2,7 @@
 
 open System
 open FsToolkit.ErrorHandling
+open Microsoft.Extensions.Logging
 open Perla.Lib
 open Types
 
@@ -513,3 +514,18 @@ module Fs =
       File.ReadAllText("./tsconfig.json") |> Some
     with
     | _ -> None
+
+[<RequireQualifiedAccess>]
+module Logging =
+
+  let getPerlaLogger () =
+    { new ILogger with
+        member _.Log(logLevel, eventId, state, ex, formatter) =
+          let format = formatter.Invoke(state, ex)
+          printfn $"Perla: {format}"
+
+        member _.IsEnabled(level) = true
+
+        member _.BeginScope(state) =
+          { new IDisposable with
+              member _.Dispose() = () } }

--- a/src/Perla.Lib/IO.fs
+++ b/src/Perla.Lib/IO.fs
@@ -485,15 +485,15 @@ module Fs =
     taskResult {
       try
         match ext with
-        | Typescript ->
+        | LoaderType.Typescript ->
           let! content = File.ReadAllTextAsync($"{file}.ts")
-          return (content, Typescript)
-        | Jsx ->
+          return (content, LoaderType.Typescript)
+        | LoaderType.Jsx ->
           let! content = File.ReadAllTextAsync($"{file}.jsx")
-          return (content, Jsx)
-        | Tsx ->
+          return (content, LoaderType.Jsx)
+        | LoaderType.Tsx ->
           let! content = File.ReadAllTextAsync($"{file}.tsx")
-          return (content, Tsx)
+          return (content, LoaderType.Tsx)
       with
       | ex -> return! ex |> Error
     }
@@ -505,9 +505,11 @@ module Fs =
         Path.GetFileNameWithoutExtension(filepath)
       )
 
-    tryReadFileWithExtension fileNoExt Typescript
-    |> TaskResult.orElseWith (fun _ -> tryReadFileWithExtension fileNoExt Jsx)
-    |> TaskResult.orElseWith (fun _ -> tryReadFileWithExtension fileNoExt Tsx)
+    tryReadFileWithExtension fileNoExt LoaderType.Typescript
+    |> TaskResult.orElseWith (fun _ ->
+      tryReadFileWithExtension fileNoExt LoaderType.Jsx)
+    |> TaskResult.orElseWith (fun _ ->
+      tryReadFileWithExtension fileNoExt LoaderType.Tsx)
 
   let tryGetTsconfigFile () =
     try

--- a/src/Perla.Lib/Perla.Lib.fsproj
+++ b/src/Perla.Lib/Perla.Lib.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>

--- a/src/Perla.Lib/Perla.Lib.fsproj
+++ b/src/Perla.Lib/Perla.Lib.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
@@ -38,7 +38,6 @@
 		<PackageReference Include="Flurl.Http" Version="3.2.0" />
 		<PackageReference Include="FSharp.Control.AsyncSeq" Version="3.2.1" />
 		<PackageReference Include="FSharp.Control.Reactive" Version="5.0.2" />
-		<PackageReference Include="Saturn" Version="0.15.0" />
 		<PackageReference Include="Hellang.Middleware.SpaFallback" Version="2.0.0" />
 		<PackageReference Include="SharpZipLib" Version="1.3.3" />
 		<PackageReference Include="FsToolkit.ErrorHandling" Version="2.12.0" />
@@ -49,5 +48,4 @@
 		<PackageReference Include="LiteDB" Version="5.0.11" />
 		<PackageReference Include="Scriban" Version="5.0.0" />
 	</ItemGroup>
-
 </Project>

--- a/src/Perla.Lib/Server.fs
+++ b/src/Perla.Lib/Server.fs
@@ -2,7 +2,6 @@
 
 open System
 open System.IO
-open System.Diagnostics
 open System.Net
 open System.Net.Http
 open System.Net.NetworkInformation
@@ -11,43 +10,136 @@ open System.Threading.Tasks
 
 open AngleSharp
 open AngleSharp.Html.Parser
+open AngleSharp.Io
 
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting.Server
 open Microsoft.AspNetCore.Hosting.Server.Features
 open Microsoft.AspNetCore.Http
-open Microsoft.AspNetCore.Hosting
 open Microsoft.Extensions.DependencyInjection
-open Microsoft.Extensions.Hosting
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.FileProviders
 open Microsoft.AspNetCore.StaticFiles
+
 open Yarp.ReverseProxy
 open Yarp.ReverseProxy.Forwarder
+
+open Hellang.Middleware.SpaFallback
 
 open FSharp.Control
 open FSharp.Control.Reactive
 
 open FsToolkit.ErrorHandling
 
-open Giraffe
-open Saturn
-open Saturn.Endpoint.Router
-
-open Hellang.Middleware.SpaFallback
-
 open CliWrap
 
+open Perla.Lib
 open Types
 open Fable
 
+
+module private LiveReload =
+  let getReloadEvent (event: Fs.FileChangedEvent) =
+    let data =
+      Json.ToTextMinified(
+        {| oldName = event.oldName
+           name = event.name |}
+      )
+
+    LiveReloadKind.FullReload, data
+
+  let getHMREvent (event: Fs.FileChangedEvent) =
+    let content = File.ReadAllText event.path
+
+    let data =
+      Json.ToTextMinified(
+        {| oldName =
+            event.oldName
+            |> Option.map (fun value ->
+              match value with
+              | Css -> value
+              | _ -> "")
+           name =
+            if Env.isWindows then
+              event.path.Replace(Path.DirectorySeparatorChar, '/')
+            else
+              event.path
+           content = content |}
+      )
+
+    HMR, data
+
+  let getLiveReloadHandler
+    isFableEnabled
+    (watcher: Fs.IFileWatcher)
+    (logger: ILogger)
+    (res: HttpResponse)
+    =
+    let watcher =
+      if isFableEnabled then
+        watcher.FileChanged
+        |> Observable.throttle (TimeSpan.FromMilliseconds(400.))
+      else
+        watcher.FileChanged
+
+    watcher
+    |> Observable.map (fun event ->
+      let kind, data =
+        match event.ChangeType with
+        | Fs.ChangeKind.Created
+        | Fs.ChangeKind.Deleted -> getReloadEvent event
+        | Fs.ChangeKind.Renamed
+        | Fs.ChangeKind.Changed ->
+          match Path.GetExtension event.name with
+          | Css -> getHMREvent event
+          | _ -> getReloadEvent event
+
+      kind, data, event)
+    |> Observable.map (fun (kind, data, event) ->
+      task {
+        match kind with
+        | LiveReloadKind.FullReload ->
+          logger.LogInformation $"LiveReload: File Changed: {event.name}"
+          do! res.WriteAsync $"event:reload\ndata:{data}\n\n"
+        | HMR ->
+          match Path.GetExtension event.name with
+          | Css ->
+            logger.LogInformation $"HMR: CSS File Changed: {event.name}"
+            do! res.WriteAsync $"event:replace-css\ndata:{data}\n\n"
+          | other ->
+            logger.LogWarning
+              $"HMR: {other.ToUpperInvariant()} File Changed: {event.name}"
+
+            logger.LogWarning
+              $"There is no HMR handler for this file... Triggering LiveReload"
+
+            do! res.WriteAsync $"event:reload\ndata:{data}\n\n"
+
+        return! res.Body.FlushAsync()
+      })
+    |> Observable.switchTask
+    |> Observable.subscribe ignore
+
+  let getCompileErrHandler (logger: ILogger) (res: HttpResponse) =
+    Fs.compileErrWatcher ()
+    |> Observable.map (fun err ->
+      task {
+        let err = Json.ToTextMinified {| error = err |}
+        logger.LogWarning $"Compilation Error: {err.Substring(0, 80)}..."
+        do! res.WriteAsync(CompileError(err).AsString)
+        return! res.Body.FlushAsync()
+      })
+    |> Observable.switchTask
+    |> Observable.subscribe ignore
+
+
 [<RequireQualifiedAccess>]
-module Middleware =
+module private Middleware =
   let transformPredicate (extensions: string list) (ctx: HttpContext) =
     extensions
-    |> List.exists (fun ext -> ctx.Request.Path.Value.Contains(ext))
+    |> List.exists ctx.Request.Path.Value.Contains
 
-  let cssImport
+  let private cssImport
     (mountedDirs: Map<string, string>)
     (ctx: HttpContext)
     (next: Func<Task>)
@@ -78,7 +170,7 @@ module Middleware =
 
         if ctx.Request.Query.ContainsKey "module" then
           logger.LogInformation("Sending CSS module")
-          ctx.SetContentType "text/css"
+          ctx.SetContentType MimeTypeNames.Css
           return! ctx.WriteStringAsync content :> Task
         else
           logger.LogInformation("Sending CSS HMR Script")
@@ -91,12 +183,12 @@ style.innerHTML = css
 style.setAttribute("filename", "{filePath.Replace(Path.DirectorySeparatorChar, '/')}");
 document.head.appendChild(style)"""
 
-          ctx.SetContentType "text/javascript"
+          ctx.SetContentType MimeTypeNames.DefaultJavaScript
           return! ctx.WriteStringAsync newContent :> Task
     }
     :> Task
 
-  let jsonImport
+  let private jsonImport
     (mountedDirs: Map<string, string>)
     (ctx: HttpContext)
     (next: Func<Task>)
@@ -126,7 +218,7 @@ document.head.appendChild(style)"""
         let newContent =
           if ctx.Request.Query.ContainsKey "module" then
             logger.LogInformation("Sending JSON Module")
-            ctx.SetContentType "text/javascript"
+            ctx.SetContentType MimeTypeNames.DefaultJavaScript
             $"export default {content}"
           else
             logger.LogInformation("Sending JSON File")
@@ -136,7 +228,7 @@ document.head.appendChild(style)"""
     }
     :> Task
 
-  let jsImport
+  let private jsImport
     (buildConfig: BuildConfig option)
     (mountedDirs: Map<string, string>)
     (ctx: HttpContext)
@@ -166,14 +258,14 @@ document.head.appendChild(style)"""
 
           Path.Combine(baseDir, fileName)
 
-        ctx.SetContentType "text/javascript"
+        ctx.SetContentType MimeTypeNames.DefaultJavaScript
 
         try
           if Path.GetExtension(filePath) <> ".js" then
             return failwith "Not a JS file, Try looking with another extension."
 
-          let! content = File.ReadAllBytesAsync(filePath)
-          do! ctx.WriteBytesAsync content :> Task
+          use content = File.OpenRead(filePath)
+          do! content.CopyToAsync ctx.Response.Body
         with
         | _ ->
           let! fileData = Esbuild.tryCompileFile filePath buildConfig
@@ -209,57 +301,32 @@ document.head.appendChild(style)"""
       )
     |> ignore
 
-
-
-module Server =
-
-  let (|Typescript|Javascript|Jsx|Css|Json|Other|) value =
-    match value with
-    | ".ts"
-    | ".tsx" -> Typescript
-    | ".js" -> Javascript
-    | ".jsx" -> Jsx
-    | ".json" -> Json
-    | ".css" -> Css
-    | _ -> Other value
-
-  type private Script =
-    | LiveReload
-    | Worker
-
-  let private sendScript (script: Script) next (ctx: HttpContext) =
+  let sendScript (script: PerlaScriptKind) (ctx: HttpContext) =
     task {
-      let basePath =
-        let assemblyLoc =
-          Path.GetDirectoryName(Reflection.Assembly.GetEntryAssembly().Location)
+      let logger = ctx.GetLogger("Perla:")
 
-        if String.IsNullOrWhiteSpace assemblyLoc then
-          Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName)
-        else
-          assemblyLoc
-
-      printfn "basePath %s" basePath
-
-      let! bytes =
+      let stream =
         match script with
         | LiveReload ->
-          File.ReadAllBytesAsync(Path.Combine(basePath, "./livereload.js"))
+          File.OpenRead(
+            Path.Combine(Path.PerlaRootDirectory, "./livereload.js")
+          )
         | Worker ->
-          File.ReadAllBytesAsync(Path.Combine(basePath, "./worker.js"))
+          File.OpenRead(Path.Combine(Path.PerlaRootDirectory, "./worker.js"))
 
-      ctx.SetContentType "text/javascript"
-      ctx.SetStatusCode 200
-      return! setBody bytes next ctx
+      logger.LogInformation($"Perla: Sending Script %A{script}")
+      return Results.Stream(stream, "text/javascript")
     }
 
-  let private Sse (watchConfig: WatchConfig) next (ctx: HttpContext) =
+  let SseHandler (watchConfig: WatchConfig) isFableEnabled (ctx: HttpContext) =
     task {
       let logger = ctx.GetLogger("Perla:SSE")
       logger.LogInformation $"LiveReload Client Connected"
-      ctx.SetStatusCode 200
       ctx.SetHttpHeader("Content-Type", "text/event-stream")
       ctx.SetHttpHeader("Cache-Control", "no-cache")
+      ctx.SetStatusCode 200
       let res = ctx.Response
+      // Start Client communication
       do! res.WriteAsync($"id:{ctx.Connection.Id}\ndata:{DateTime.Now}\n\n")
       do! res.Body.FlushAsync()
 
@@ -267,80 +334,10 @@ module Server =
 
       logger.LogInformation $"Watching %A{watchConfig.directories} for changes"
 
-      let onCompileErrSub =
-        Fs
-          .compileErrWatcher()
-          .Subscribe(fun err ->
-            let err = Json.ToTextMinified {| error = err |}
-            logger.LogWarning $"Compilation Error"
-
-            task {
-              do! res.WriteAsync $"event:compile-err\ndata:{err}\n\n"
-              return! res.Body.FlushAsync()
-            }
-            |> Async.AwaitTask
-            |> Async.StartImmediate)
+      let onCompileErrSub = LiveReload.getCompileErrHandler logger res
 
       let onChangeSub =
-        watcher.FileChanged
-        |> Observable.map (fun event ->
-          task {
-            match Path.GetExtension event.name with
-            | Css ->
-              match event.ChangeType with
-              | Fs.ChangeKind.Created
-              | Fs.ChangeKind.Deleted ->
-                let data =
-                  Json.ToTextMinified(
-                    {| oldName = event.oldName
-                       name = event.name |}
-                  )
-
-                logger.LogInformation $"LiveReload File Changed: {event.name}"
-
-                do! res.WriteAsync $"event:reload\ndata:{data}\n\n"
-              | Fs.ChangeKind.Renamed
-              | Fs.ChangeKind.Changed ->
-                let! content = File.ReadAllTextAsync event.path
-
-                let data =
-                  Json.ToTextMinified(
-                    {| oldName =
-                        event.oldName
-                        |> Option.map (fun value ->
-                          match value with
-                          | Css -> value
-                          | _ -> "")
-                       name =
-                        if Env.isWindows then
-                          event.path.Replace(Path.DirectorySeparatorChar, '/')
-                        else
-                          event.path
-                       content = content |}
-                  )
-
-                logger.LogInformation $"CSS File Changed: {event.name}"
-                do! res.WriteAsync $"event:replace-css\ndata:{data}\n\n"
-
-              return! res.Body.FlushAsync()
-            | Typescript
-            | Javascript
-            | Jsx
-            | Json
-            | Other _ ->
-              let data =
-                Json.ToTextMinified(
-                  {| oldName = event.oldName
-                     name = event.name |}
-                )
-
-              logger.LogInformation $"LiveReload File Changed: {event.name}"
-
-              do! res.WriteAsync $"event:reload\ndata:{data}\n\n"
-              return! res.Body.FlushAsync()
-          })
-        |> Observable.switchTask
-        |> Observable.subscribe ignore
+        LiveReload.getLiveReloadHandler isFableEnabled watcher logger res
 
       ctx.RequestAborted.Register (fun _ ->
         watcher.Dispose()
@@ -351,26 +348,12 @@ module Server =
       while true do
         do! Async.Sleep(TimeSpan.FromSeconds 1.)
 
-      return! text "" next ctx
+      return Results.Ok()
     }
 
-  let private isAddressPortOccupied (address: string) (port: int) =
-    let didParse, address = IPEndPoint.TryParse($"{address}:{port}")
-
-    if didParse then
-      let props = IPGlobalProperties.GetIPGlobalProperties()
-
-      let listeners = props.GetActiveTcpListeners()
-
-      listeners
-      |> Array.map (fun listener -> listener.Port)
-      |> Array.contains address.Port
-    else
-      false
-
-  let private Index next (ctx: HttpContext) =
+  let IndexHandler (ctx: HttpContext) =
     task {
-      let logger = ctx.GetLogger("Perla:Index")
+      let logger = ctx.GetLogger("Perla")
 
       match Fs.getPerlaConfig (Path.GetPerlaConfigPath()) with
       | Error err ->
@@ -380,7 +363,11 @@ module Server =
           err
         )
 
-        return! htmlFile (Path.Combine("./public", "index.html")) next ctx
+        return
+          Results.Stream(
+            File.OpenRead(Path.GetFullPath("./index.html")),
+            MimeTypeNames.Html
+          )
       | Ok config ->
 
         let indexFile = defaultArg config.index "index.html"
@@ -394,7 +381,7 @@ module Server =
         let liveReload = doc.CreateElement "script"
         let script = doc.CreateElement "script"
         script.SetAttribute("type", "importmap")
-        liveReload.SetAttribute("type", "text/javascript")
+        liveReload.SetAttribute("type", MimeTypeNames.DefaultJavaScript)
         liveReload.SetAttribute("src", "/~perla~/livereload.js")
 
         match! Fs.getOrCreateLockFile (Path.GetPerlaConfigPath()) with
@@ -406,7 +393,7 @@ module Server =
           script.TextContent <- Json.ToText map
           doc.Head.AppendChild script |> ignore
           doc.Body.AppendChild liveReload |> ignore
-          return! htmlString (doc.ToHtml()) next ctx
+          return Results.Text(doc.ToHtml(), MimeTypeNames.Html)
         | Error err ->
 
           logger.LogError(
@@ -414,23 +401,14 @@ module Server =
             err
           )
 
-          return! htmlFile (Path.GetFullPath(indexFile)) next ctx
+          return
+            Results.Stream(
+              File.OpenRead(Path.GetFullPath(indexFile)),
+              MimeTypeNames.Html
+            )
     }
 
-  let mutable private app: IHost option = None
-
-  let private getHttpClientAndForwarder () =
-    let socketsHandler = new SocketsHttpHandler()
-    socketsHandler.UseProxy <- false
-    socketsHandler.AllowAutoRedirect <- false
-    socketsHandler.AutomaticDecompression <- DecompressionMethods.None
-    socketsHandler.UseCookies <- false
-    let client = new HttpMessageInvoker(socketsHandler)
-    let reqConfig = ForwarderRequestConfig()
-    reqConfig.ActivityTimeout <- TimeSpan.FromSeconds(100.)
-    client, reqConfig
-
-  let private getProxyHandler
+  let getProxyHandler
     (target: string)
     (httpClient: HttpMessageInvoker)
     (forwardConfig: ForwarderRequestConfig)
@@ -449,23 +427,45 @@ module Server =
 
     Func<HttpContext, IHttpForwarder, Task>(toFunc)
 
+module Server =
+  // Local App instance that we use in case we want to kill/restart
+  // The server via the interactive commands
+  let mutable private app: WebApplication voption = ValueNone
+
+  let private isAddressPortOccupied (address: string) (port: int) =
+    let didParse, address = IPEndPoint.TryParse($"{address}:{port}")
+
+    if didParse then
+      let props = IPGlobalProperties.GetIPGlobalProperties()
+
+      let listeners = props.GetActiveTcpListeners()
+
+      listeners
+      |> Array.map (fun listener -> listener.Port)
+      |> Array.contains address.Port
+    else
+      false
+
+  let private getHttpClientAndForwarder () =
+    let socketsHandler = new SocketsHttpHandler()
+    socketsHandler.UseProxy <- false
+    socketsHandler.AllowAutoRedirect <- false
+    socketsHandler.AutomaticDecompression <- DecompressionMethods.None
+    socketsHandler.UseCookies <- false
+    let client = new HttpMessageInvoker(socketsHandler)
+    let reqConfig = ForwarderRequestConfig()
+    reqConfig.ActivityTimeout <- TimeSpan.FromSeconds(100.)
+    client, reqConfig
+
   let private startFable =
     let getFableCmd (config: FableConfig option) =
       let logger =
-        voption {
-          let! app = app
-
-          let! logger =
-            app.Services.GetService<ILogger>()
-            |> ValueOption.ofObj
-
-          return fun value -> logger.LogInformation $"Perla: %s{value}"
-        }
-        |> ValueOption.defaultValue (fun value ->
-          if String.IsNullOrWhiteSpace value then
-            ()
-          else
-            printfn $"Perla: %s{value}")
+        app
+        |> ValueOption.map (fun app ->
+          app.Services.GetService<ILogger>()
+          |> ValueOption.ofObj)
+        |> ValueOption.flatten
+        |> ValueOption.defaultValue (Logging.getPerlaLogger ())
 
       let inline logAddresses () =
         let addresses =
@@ -489,18 +489,18 @@ module Server =
             addresses
             |> Seq.reduce (fun current next -> $"\n\t{current}\n\t{next}")
 
-          logger $"Listening at {value}"
+          logger.LogInformation $"Listening at {value}"
         | ValueNone -> ()
 
       (fableCmd (Some true) (defaultArg config (FableConfig.DefaultConfig())))
         .WithValidation(CommandResultValidation.None)
         .WithStandardOutputPipe(
           PipeTarget.ToDelegate (fun value ->
-            if value.ToLowerInvariant().Contains("watching...") then
-              logger value
+            if value.ToLowerInvariant().Contains("watching") then
+              logger.LogInformation value
               logAddresses ()
             else
-              logger value)
+              logger.LogInformation value)
         )
 
     startFable getFableCmd
@@ -508,6 +508,7 @@ module Server =
   let private devServer (config: PerlaConfig) =
     let serverConfig =
       defaultArg config.devServer (DevServerConfig.DefaultConfig())
+    let builder = WebApplication.CreateBuilder()
 
     let getProxyConfig =
       let path = Path.GetProxyConfigPath()
@@ -523,134 +524,133 @@ module Server =
     let watchConfig =
       defaultArg serverConfig.watchConfig (WatchConfig.Default())
 
-    let app =
-      let urls =
-        if liveReload then
-          router {
-            get "/" Index
-            get "index.html" Index
-            get "/~perla~/sse" (Sse watchConfig)
-            get "/~perla~/livereload.js" (sendScript LiveReload)
-            get "/~perla~/worker.js" (sendScript Worker)
-          }
-        else
-          router {
-            get "/" Index
-            get "index.html" Index
-          }
-
-      let withWebhostConfig (config: IWebHostBuilder) =
-        let http, https =
-          match isAddressPortOccupied customHost customPort with
-          | false ->
-            if useSSL then
-              $"http://{customHost}:{customPort - 1}",
-              $"https://{customHost}:{customPort}"
-            else
-              $"http://{customHost}:{customPort}",
-              $"https://{customHost}:{customPort + 1}"
-          | true ->
-            printfn
-              $"Address {customHost}:{customPort} is busy, selecting a dynamic port."
-
-            $"http://{customHost}:{0}", $"https://{customHost}:{0}"
-
-        config.UseUrls(http, https)
-
-      let withAppConfig (appConfig: IApplicationBuilder) =
+    let http, https =
+      match isAddressPortOccupied customHost customPort with
+      | false ->
         if useSSL then
-          appConfig.UseHsts().UseHttpsRedirection()
-          |> ignore
+          $"http://{customHost}:{customPort - 1}",
+          $"https://{customHost}:{customPort}"
+        else
+          $"http://{customHost}:{customPort}",
+          $"https://{customHost}:{customPort + 1}"
+      | true ->
+        printfn
+          $"Perla: Address {customHost}:{customPort} is busy, selecting a dynamic port."
 
-        appConfig.UseSpaFallback() |> ignore
+        $"http://{customHost}:{0}", $"https://{customHost}:{0}"
 
-        let ignoreStatic =
-          [ ".js"
-            ".css"
-            ".module.css"
-            ".ts"
-            ".tsx"
-            ".jsx"
-            ".json" ]
 
-        for map in mountedDirs do
-          let staticFileOptions =
-            let provider = FileExtensionContentTypeProvider()
+    builder.Services.AddSpaFallback() |> ignore
 
-            for ext in ignoreStatic do
-              provider.Mappings.Remove(ext) |> ignore
+    getProxyConfig
+    |> Option.iter (fun _ -> builder.Services.AddHttpForwarder() |> ignore)
 
-            let options = StaticFileOptions()
+    let app = builder.Build()
 
-            options.ContentTypeProvider <- provider
-            options.RequestPath <- PathString(map.Value)
+    app.Urls.Add(http)
+    app.Urls.Add(https)
 
-            options.FileProvider <-
-              new PhysicalFileProvider(Path.GetFullPath(map.Key))
+    app.MapGet("/", Func<HttpContext, Task<IResult>>(Middleware.IndexHandler))
+    |> ignore
 
-            options
+    app.MapGet(
+      "/index.html",
+      Func<HttpContext, Task<IResult>>(Middleware.IndexHandler)
+    )
+    |> ignore
 
-          appConfig.UseStaticFiles staticFileOptions
-          |> ignore
+    if liveReload then
+      app.MapGet(
+        "/~perla~/sse",
+        Func<HttpContext, Task<IResult>>(
+          Middleware.SseHandler watchConfig (config.fable |> Option.isSome)
+        )
+      )
+      |> ignore
 
-        let appConfig =
-          appConfig.UseWhen(
-            Middleware.transformPredicate ignoreStatic,
-            Middleware.configureTransformMiddleware config
-          )
+      app.MapGet(
+        "/~perla~/livereload.js",
+        Func<HttpContext, Task<IResult>>(Middleware.sendScript LiveReload)
+      )
+      |> ignore
 
-        match getProxyConfig with
-        | Some proxyConfig ->
-          appConfig
-            .UseRouting()
-            .UseEndpoints(fun endpoints ->
-              let client, reqConfig = getHttpClientAndForwarder ()
+      app.MapGet(
+        "/~perla~/worker.js",
+        Func<HttpContext, Task<IResult>>(Middleware.sendScript Worker)
+      )
+      |> ignore
 
-              for from, target in proxyConfig |> Map.toSeq do
-                let handler = getProxyHandler target client reqConfig
-                endpoints.Map(from, handler) |> ignore)
-        | None -> appConfig
+    if useSSL then
+      app.UseHsts().UseHttpsRedirection() |> ignore
 
-      let setServices
-        (proxyConfig: Map<string, string> option)
-        (services: IServiceCollection)
-        =
-        services.AddSpaFallback() |> ignore
+    app.UseSpaFallback() |> ignore
 
-        match proxyConfig with
-        | Some _ -> services.AddHttpForwarder()
-        | None -> services
+    let ignoreStatic =
+      [ ".js"
+        ".css"
+        ".module.css"
+        ".ts"
+        ".tsx"
+        ".jsx"
+        ".json" ]
 
-      application {
-        app_config withAppConfig
-        service_config (setServices getProxyConfig)
-        webhost_config withWebhostConfig
-        use_endpoint_router urls
-        use_gzip
-      }
+    for map in mountedDirs do
+      let staticFileOptions =
+        let provider = FileExtensionContentTypeProvider()
+
+        for ext in ignoreStatic do
+          provider.Mappings.Remove(ext) |> ignore
+
+        let options = StaticFileOptions()
+
+        options.ContentTypeProvider <- provider
+        options.RequestPath <- PathString(map.Value)
+
+        options.FileProvider <-
+          new PhysicalFileProvider(Path.GetFullPath(map.Key))
+
+        options
+
+      app.UseStaticFiles staticFileOptions |> ignore
+
+    app.UseWhen(
+      Middleware.transformPredicate ignoreStatic,
+      Middleware.configureTransformMiddleware config
+    )
+    |> ignore
+
+    match getProxyConfig with
+    | Some proxyConfig ->
+      app
+        .UseRouting()
+        .UseEndpoints(fun endpoints ->
+          let client, reqConfig = getHttpClientAndForwarder ()
+
+          for from, target in proxyConfig |> Map.toSeq do
+            let handler = Middleware.getProxyHandler target client reqConfig
+            endpoints.Map(from, handler) |> ignore)
+      |> ignore
+    | None -> ()
 
     app
-      .UseEnvironment(Environments.Development)
-      .Build()
 
   let private stopServer () =
     match app with
-    | Some actual ->
+    | ValueSome actual ->
       task {
         do! actual.StopAsync()
-        actual.Dispose()
-        app <- None
+        app <- ValueNone
       }
       :> Task
-    | None -> Task.FromResult(()) :> Task
+    | ValueNone -> Task.FromResult(()) :> Task
 
   let private startServer (config: PerlaConfig) =
     match app with
-    | None ->
+    | ValueNone ->
       let dev = devServer config
-      app <- Some dev
+      app <- ValueSome dev
       task { return! dev.StartAsync() }
-    | Some app ->
+    | ValueSome app ->
       task {
         do! stopServer ()
         return! app.StartAsync()

--- a/src/Perla.Lib/Types.fs
+++ b/src/Perla.Lib/Types.fs
@@ -27,10 +27,40 @@ module Types =
     | "stop" -> Exit
     | value -> Unknown value
 
+  let (|Typescript|Javascript|Jsx|Css|Json|Other|) value =
+    match value with
+    | ".ts"
+    | ".tsx" -> Typescript
+    | ".js" -> Javascript
+    | ".jsx" -> Jsx
+    | ".json" -> Json
+    | ".css" -> Css
+    | _ -> Other value
+
   type LoaderType =
     | Typescript
     | Tsx
     | Jsx
+
+  type LiveReloadKind =
+    | FullReload
+    | HMR
+
+  type PerlaScriptKind =
+    | LiveReload
+    | Worker
+
+  type LiveReloadEvents =
+    | FullReload of string
+    | ReplaceCSS of string
+    | CompileError of string
+
+    member this.AsString =
+      match this with
+      | FullReload data -> $"event:reload\ndata:{data}\n\n"
+      | ReplaceCSS data -> $"event:replace-css\ndata:{data}\n\n"
+      | CompileError err -> $"event:compile-err\ndata:{err}\n\n"
+
 
   type FableConfig =
     { autoStart: bool option

--- a/src/Perla.Lib/Types.fs
+++ b/src/Perla.Lib/Types.fs
@@ -37,20 +37,24 @@ module Types =
     | ".css" -> Css
     | _ -> Other value
 
+  [<RequireQualifiedAccess>]
   type LoaderType =
     | Typescript
     | Tsx
     | Jsx
 
-  type LiveReloadKind =
+  [<RequireQualifiedAccess>]
+  type ReloadKind =
     | FullReload
     | HMR
 
-  type PerlaScriptKind =
+  [<RequireQualifiedAccess>]
+  type PerlaScript =
     | LiveReload
     | Worker
 
-  type LiveReloadEvents =
+  [<RequireQualifiedAccess>]
+  type ReloadEvents =
     | FullReload of string
     | ReplaceCSS of string
     | CompileError of string

--- a/src/Perla/Program.fs
+++ b/src/Perla/Program.fs
@@ -1,11 +1,12 @@
 ﻿// Learn more about F# at http://docs.microsoft.com/dotnet/fsharp
 open System.Threading.Tasks
 
+open System
 open Argu
 open FsToolkit.ErrorHandling
+open Perla
 open Perla.Lib
 open Types
-open Perla
 
 
 let processExit (result: Task<Result<int, exn>>) =
@@ -24,7 +25,7 @@ let processExit (result: Task<Result<int, exn>>) =
 let main argv =
   taskResult {
     let parser = ArgumentParser.Create<DevServerArgs>()
-
+    Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development")
     try
       let parsed =
         parser.ParseCommandLine(

--- a/src/Perla/Properties/launchSettings.json
+++ b/src/Perla/Properties/launchSettings.json
@@ -5,6 +5,11 @@
       "commandLineArgs": "serve",
       "workingDirectory": "$(ProjectDir)/../App"
     },
+    "Serve Docs": {
+      "commandName": "Project",
+      "commandLineArgs": "serve",
+      "workingDirectory": "$(ProjectDir)/../docs"
+    },
     "Add Template": {
       "commandName": "Project",
       "commandLineArgs": "add-template -n AngelMunoz/perla-samples -b clam-poc",


### PR DESCRIPTION
I decided to drop saturn since we're not really using any critical or killer feature of saturn (like controllers, routing, pipelines etc).

Also I did some re-organization and refactoring around the `devServer` function, overall it should be cleaner it still has some messy things inside but I think we can live with that for the mean time.

All of the middleware/endpoint handlers were moved to the `Middleware` module since it makes sence to have them there rather than having them local to the `devServer` function.

All of the LiveReload related handlers/watchers were also moved into it's own module and added a few extra types to make things a little bit more type safe and to allow a better flow control on the observables for file monitors, also adds support for #72 when fable is enabled on the project
