### PR TITLE
Mount on root copy re target

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -1,11 +1,11 @@
 ﻿#!/usr/bin/env -S dotnet fsi
-#r "nuget: Fake.DotNet.Cli, 5.20.4"
-#r "nuget: Fake.IO.FileSystem, 5.20.4"
-#r "nuget: Fake.Core.Target, 5.20.4"
-#r "nuget: Fake.DotNet.MsBuild, 5.20.4"
-#r "nuget: MSBuild.StructuredLogger, 2.1.507"
+#r "nuget: Fake.DotNet.Cli, 5.22.0"
+#r "nuget: Fake.IO.FileSystem, 5.22.0"
+#r "nuget: Fake.Core.Target, 5.22.0"
+#r "nuget: Fake.DotNet.MsBuild, 5.22.0"
+#r "nuget: MSBuild.StructuredLogger, 2.1.630"
 #r "nuget: System.IO.Compression.ZipFile, 4.3.0"
-#r "nuget: System.Reactive"
+#r "nuget: System.Reactive, 5.0.0"
 
 open System
 open System.IO.Compression

--- a/src/Perla.Lib/Esbuild.fs
+++ b/src/Perla.Lib/Esbuild.fs
@@ -207,6 +207,7 @@ module Esbuild =
         "esbuild is not present, setting esbuild...",
         fun context ->
           context.Status <- "Downloading esbuild..."
+
           tryDownloadEsBuild esbuildVersion
           |> (fun path ->
             context.Status <- "Extracting esbuild..."

--- a/src/Perla.Lib/Perla.Lib.fsproj
+++ b/src/Perla.Lib/Perla.Lib.fsproj
@@ -49,8 +49,4 @@
 		<PackageReference Include="LiteDB" Version="5.0.11" />
 		<PackageReference Include="Scriban" Version="5.4.4" />
 	</ItemGroup>
-
-	<ItemGroup>
-	  <PackageReference Update="FSharp.Core" Version="6.0.3" />
-	</ItemGroup>
 </Project>

--- a/src/Perla.Lib/Server.fs
+++ b/src/Perla.Lib/Server.fs
@@ -135,6 +135,21 @@ module private LiveReload =
 
 [<RequireQualifiedAccess>]
 module private Middleware =
+  let tryFindMounted (path: string) mountedDirs =
+    mountedDirs
+    |> Map.tryPick (fun k v ->
+      option {
+        let dirname = Path.GetDirectoryName path
+
+        if v = String.Empty && dirname = @"\"
+           || dirname = "/" then
+          return (k, v)
+        elif v <> String.Empty && path.StartsWith v then
+          return (k, v)
+        else
+          return! None
+      })
+
   let transformPredicate (extensions: string list) (ctx: HttpContext) =
     extensions
     |> List.exists ctx.Request.Path.Value.Contains
@@ -152,39 +167,40 @@ module private Middleware =
         let logger = ctx.GetLogger("Perla Middleware")
         let path = ctx.Request.Path.Value
 
-        let baseDir, baseName =
-          mountedDirs
-          |> Map.filter (fun _ v -> String.IsNullOrWhiteSpace v |> not)
-          |> Map.toSeq
-          |> Seq.find (fun (_, v) -> path.StartsWith(v))
+        match tryFindMounted path mountedDirs with
+        | Some (baseDir, baseName) ->
+          let filePath =
+            let fileName =
+              path.Replace(
+                $"{baseName}/",
+                "",
+                StringComparison.InvariantCulture
+              )
 
-        let filePath =
-          let fileName =
-            path.Replace($"{baseName}/", "", StringComparison.InvariantCulture)
+            Path.Combine(baseDir, fileName)
 
-          Path.Combine(baseDir, fileName)
+          logger.LogInformation("Transforming CSS")
 
-        logger.LogInformation("Transforming CSS")
+          let! content = File.ReadAllTextAsync(filePath)
 
-        let! content = File.ReadAllTextAsync(filePath)
+          if ctx.Request.Query.ContainsKey "module" then
+            logger.LogInformation("Sending CSS module")
+            ctx.SetContentType MimeTypeNames.Css
+            return! ctx.WriteStringAsync content :> Task
+          else
+            logger.LogInformation("Sending CSS HMR Script")
 
-        if ctx.Request.Query.ContainsKey "module" then
-          logger.LogInformation("Sending CSS module")
-          ctx.SetContentType MimeTypeNames.Css
-          return! ctx.WriteStringAsync content :> Task
-        else
-          logger.LogInformation("Sending CSS HMR Script")
-
-          let newContent =
-            $"""
-const css = `{content}`
-const style = document.createElement('style')
-style.innerHTML = css
-style.setAttribute("filename", "{filePath.Replace(Path.DirectorySeparatorChar, '/')}");
+            let newContent =
+              $"""const css = `{content}`,style = document.createElement('style')
+style.innerHTML = css;style.setAttribute("filename", "{filePath.Replace(Path.DirectorySeparatorChar, '/')}");
 document.head.appendChild(style)"""
 
-          ctx.SetContentType MimeTypeNames.DefaultJavaScript
-          return! ctx.WriteStringAsync newContent :> Task
+            ctx.SetContentType MimeTypeNames.DefaultJavaScript
+            return! ctx.WriteStringAsync newContent :> Task
+        | None ->
+          logger.LogInformation $"Failed to find: {path}"
+          ctx.Response.StatusCode <- 404
+          return! ctx.Response.CompleteAsync()
     }
     :> Task
 
@@ -201,30 +217,35 @@ document.head.appendChild(style)"""
         let logger = ctx.GetLogger("Perla Middleware")
         let path = ctx.Request.Path.Value
 
-        let baseDir, baseName =
-          mountedDirs
-          |> Map.filter (fun _ v -> String.IsNullOrWhiteSpace v |> not)
-          |> Map.toSeq
-          |> Seq.find (fun (_, v) -> path.StartsWith(v))
+        match tryFindMounted path mountedDirs with
+        | Some (baseDir, baseName) ->
 
-        let filePath =
-          let fileName =
-            path.Replace($"{baseName}/", "", StringComparison.InvariantCulture)
+          let filePath =
+            let fileName =
+              path.Replace(
+                $"{baseName}/",
+                "",
+                StringComparison.InvariantCulture
+              )
 
-          Path.Combine(baseDir, fileName)
+            Path.Combine(baseDir, fileName)
 
-        let! content = File.ReadAllTextAsync(filePath)
+          let! content = File.ReadAllTextAsync(filePath)
 
-        let newContent =
-          if ctx.Request.Query.ContainsKey "module" then
-            logger.LogInformation("Sending JSON Module")
-            ctx.SetContentType MimeTypeNames.DefaultJavaScript
-            $"export default {content}"
-          else
-            logger.LogInformation("Sending JSON File")
-            content
+          let newContent =
+            if ctx.Request.Query.ContainsKey "module" then
+              logger.LogInformation("Sending JSON Module")
+              ctx.SetContentType MimeTypeNames.DefaultJavaScript
+              $"export default {content}"
+            else
+              logger.LogInformation("Sending JSON File")
+              content
 
-        do! ctx.WriteStringAsync newContent :> Task
+          do! ctx.WriteStringAsync newContent :> Task
+        | None ->
+          logger.LogInformation $"Failed to find: {path}"
+          ctx.Response.StatusCode <- 404
+          return! ctx.Response.CompleteAsync()
     }
     :> Task
 
@@ -246,41 +267,46 @@ document.head.appendChild(style)"""
         let path = ctx.Request.Path.Value
         logger.LogInformation($"Serving {path}")
 
-        let baseDir, baseName =
-          mountedDirs
-          |> Map.filter (fun _ v -> String.IsNullOrWhiteSpace v |> not)
-          |> Map.toSeq
-          |> Seq.find (fun (_, v) -> path.StartsWith(v))
+        match tryFindMounted path mountedDirs with
+        | Some (baseDir, baseName) ->
+          let filePath =
+            let fileName =
+              path.Replace(
+                $"{baseName}/",
+                "",
+                StringComparison.InvariantCulture
+              )
 
-        let filePath =
-          let fileName =
-            path.Replace($"{baseName}/", "", StringComparison.InvariantCulture)
+            Path.Combine(baseDir, fileName)
 
-          Path.Combine(baseDir, fileName)
+          ctx.SetContentType MimeTypeNames.DefaultJavaScript
 
-        ctx.SetContentType MimeTypeNames.DefaultJavaScript
+          try
+            if Path.GetExtension(filePath) <> ".js" then
+              return
+                failwith "Not a JS file, Try looking with another extension."
 
-        try
-          if Path.GetExtension(filePath) <> ".js" then
-            return failwith "Not a JS file, Try looking with another extension."
+            use content = File.OpenRead(filePath)
+            do! content.CopyToAsync ctx.Response.Body
+          with
+          | _ ->
+            let! fileData = Esbuild.tryCompileFile filePath buildConfig
 
-          use content = File.OpenRead(filePath)
-          do! content.CopyToAsync ctx.Response.Body
-        with
-        | _ ->
-          let! fileData = Esbuild.tryCompileFile filePath buildConfig
-
-          match fileData with
-          | Ok (stdout, stderr) ->
-            if String.IsNullOrWhiteSpace stderr |> not then
-              Fs.PublishCompileErr stderr
-              do! ctx.WriteBytesAsync [||] :> Task
-            else
-              let content = Encoding.UTF8.GetBytes stdout
-              do! ctx.WriteBytesAsync content :> Task
-          | Error err ->
-            ctx.SetStatusCode 500
-            do! ctx.WriteTextAsync err.Message :> Task
+            match fileData with
+            | Ok (stdout, stderr) ->
+              if String.IsNullOrWhiteSpace stderr |> not then
+                Fs.PublishCompileErr stderr
+                do! ctx.WriteBytesAsync [||] :> Task
+              else
+                let content = Encoding.UTF8.GetBytes stdout
+                do! ctx.WriteBytesAsync content :> Task
+            | Error err ->
+              ctx.SetStatusCode 500
+              do! ctx.WriteTextAsync err.Message :> Task
+        | None ->
+          logger.LogInformation $"Failed to find: {path}"
+          ctx.Response.StatusCode <- 404
+          return! ctx.Response.CompleteAsync()
     }
     :> Task
 

--- a/src/Perla/Perla.fsproj
+++ b/src/Perla/Perla.fsproj
@@ -23,8 +23,4 @@
     <ProjectReference Include="..\Perla.Lib\Perla.Lib.fsproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="6.0.3" />
-  </ItemGroup>
-
 </Project>

--- a/src/Perla/Properties/launchSettings.json
+++ b/src/Perla/Properties/launchSettings.json
@@ -10,6 +10,11 @@
       "commandLineArgs": "serve",
       "workingDirectory": "$(ProjectDir)/../docs"
     },
+    "Build Docs": {
+      "commandName": "Project",
+      "commandLineArgs": "build",
+      "workingDirectory": "$(ProjectDir)/../docs"
+    },
     "Add Template": {
       "commandName": "Project",
       "commandLineArgs": "add-template -n AngelMunoz/perla-samples -b clam-poc",

--- a/src/docs/index.html
+++ b/src/docs/index.html
@@ -41,6 +41,17 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      if ("serviceWorker" in navigator) {
+        // Use the window load event to keep the page load performant
+        window.addEventListener("load", () => {
+          navigator.serviceWorker
+                  .register("/sw.js")
+                  .catch(console.warn)
+                  .then(console.log);
+        });
+      }
+    </script>
     <script data-entry-point type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/src/docs/perla.jsonc
+++ b/src/docs/perla.jsonc
@@ -4,11 +4,17 @@
   "devServer": {
     "mountDirectories": {
       "./assets": "/assets",
-      "./src": "/src"
+      "./src": "/src",
+      "./sw": ""
     },
     "liveReload": true
   },
   "build": {
+    "copyPaths": {
+      "includes": [
+        "./sw/sw.js -> ./sw.js"
+      ]
+    },
     "injects": [
       "./react-shim.js"
     ]

--- a/src/docs/sw/sw.js
+++ b/src/docs/sw/sw.js
@@ -1,0 +1,47 @@
+importScripts(
+    'https://storage.googleapis.com/workbox-cdn/releases/6.4.1/workbox-sw.js'
+);
+
+workbox.setConfig({ debug: true });
+const { strategies, routing } = workbox;
+const pathEndsWith = (url, ext) => url?.pathname?.endsWith(ext);
+const hostContains = (url, ext) => url?.host?.includes(ext);
+const isGet = (request) => request.method === 'GET';
+
+routing.registerRoute(
+    ({ event, request, url }) => {
+        return isGet(request) && request.destination === 'image'
+    },
+    new strategies.CacheFirst({ cacheName: 'images' })
+);
+
+routing.registerRoute(
+    ({ event, request, url }) => {
+        return isGet(request) && pathEndsWith(url, ".md")
+    },
+    new strategies.CacheFirst({ cacheName: 'markdown' })
+);
+
+routing.registerRoute(
+    ({event, request, url}) =>
+        isGet(request)
+        && request.destination === 'script'
+        && !url?.pathname.includes("~perla~")
+        && !(hostContains(url, "cdn.skypack.dev") || hostContains(url, "cdn.jsdelivr.net") || hostContains(url, "ga.jspm.io")),
+    new strategies.StaleWhileRevalidate({ cacheName: 'scripts' })
+);
+
+routing.registerRoute(
+    ({event, request, url}) =>
+        isGet(request)
+        && request.destination === 'script'
+        && !url?.pathname.includes("~perla~")
+        && (hostContains(url, "cdn.skypack.dev") || hostContains(url, "cdn.jsdelivr.net") || hostContains(url, "ga.jspm.io")),
+    new strategies.CacheFirst({ cacheName: 'cdn-cache' })
+);
+
+
+routing.registerRoute(
+    ({event, request, url}) => isGet(request) && request.destination === 'style',
+    new strategies.StaleWhileRevalidate({ cacheName: 'styles' })
+);


### PR DESCRIPTION
This PR partially addresses #73 
you can't mount individual files but you now are able to mount files on the dev server root as well as being able to control where certain files are copied if needed

This is mainly to support service workers and enable PWAs with Perla