### PR TITLE
Scaffolding Overhaul

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -10,7 +10,7 @@ nuget FSharp.Control.AsyncSeq 3.2.1
 nuget FSharp.Control.Reactive 5.0.5
 nuget FsToolkit.ErrorHandling >= 4.4.0
 nuget FsToolkit.ErrorHandling.TaskResult >= 4.4.0
-nuget FSharp.SystemCommandLine >= 0.15.0-beta4 prerelease
+nuget FSharp.SystemCommandLine >= 0.17.0-beta4 prerelease
 
 nuget AngleSharp 1.0.1
 nuget Flurl.Http 3.2.4

--- a/paket.lock
+++ b/paket.lock
@@ -46,7 +46,7 @@ NUGET
       FSharp.Core (>= 4.7.2)
       System.Reactive (>= 5.0 < 6.0)
     FSharp.Core (7.0.200)
-    FSharp.SystemCommandLine (0.15.0-beta4)
+    FSharp.SystemCommandLine (0.17.0-beta4)
       FSharp.Core (>= 6.0)
       System.CommandLine (>= 2.0.0-beta4.22272.1)
     FSharp.UMX (1.1)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,11 +10,12 @@
         <RepositoryUrl>https://github.com/AngelMunoz/Perla.git</RepositoryUrl>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <WarnOn>3390;$(WarnOn)</WarnOn>
     </PropertyGroup>
     <ItemGroup>
-        <None Include="$(MSBuildThisFileDirectory)\..\LICENSE" Pack="true" Visible="false" PackagePath=""/>
-        <None Include="$(MSBuildThisFileDirectory)\..\README.md" Pack="true" Visible="false" PackagePath=""/>
+        <None Include="$(MSBuildThisFileDirectory)\..\LICENSE" Pack="true" PackagePath="\"/>
+        <None Include="$(MSBuildThisFileDirectory)\..\README.md" Pack="true" PackagePath="\"/>
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/src/Perla.PackageManager/Types.fs
+++ b/src/Perla.PackageManager/Types.fs
@@ -89,6 +89,7 @@ module Types =
     | Unpkg
     | Jsdelivr
     | JspmSystem
+    | EsmSh
 
     member this.AsString =
       match this with
@@ -96,7 +97,8 @@ module Types =
       | Skypack -> "skypack"
       | Unpkg -> "unpkg"
       | Jsdelivr -> "jsdelivr"
-      | JspmSystem -> "jspm.system"
+      | JspmSystem -> "jspm#system"
+      | EsmSh -> "esm.sh"
 
     static member FromString(value: string) =
       match value.ToLowerInvariant() with
@@ -105,6 +107,9 @@ module Types =
       | "unpkg" -> Unpkg
       | "jsdelivr" -> Jsdelivr
       | "jspm.system" -> JspmSystem
+      | "jspm#system" -> JspmSystem
+      | "esm.sh" -> EsmSh
+      | "esmsh" -> EsmSh
       | _ -> Jspm
 
 module Constants =
@@ -130,7 +135,8 @@ module TypeExtensions =
         map: ImportMap,
         imports: Dictionary<string, string>
       ) =
-      { map with imports = imports.ToSeq() |> Map.ofSeq }
+      { map with
+          imports = imports.ToSeq() |> Map.ofSeq }
 
     [<Extension>]
     static member WithScopes

--- a/src/Perla.PackageManager/Types.fsi
+++ b/src/Perla.PackageManager/Types.fsi
@@ -59,6 +59,7 @@ module Types =
         | Unpkg
         | Jsdelivr
         | JspmSystem
+        | EsmSh
 
         member AsString: string
 

--- a/src/Perla/Commands.fs
+++ b/src/Perla/Commands.fs
@@ -1,2258 +1,706 @@
-﻿namespace Perla
+﻿[<RequireQualifiedAccess>]
+module Perla.Commands
 
-open System
+open System.Threading
+
 open System.CommandLine
 open System.CommandLine.Invocation
 open System.CommandLine.Parsing
-open System.IO
 
-open System.Threading
-open System.Threading.Tasks
+open FSharp.SystemCommandLine
+open FSharp.SystemCommandLine.Aliases
 
-open Microsoft.Playwright
-open Spectre.Console
-
-open FSharp.Control
-open FSharp.Control.Reactive
-
-open FSharp.UMX
 open FsToolkit.ErrorHandling
 
-open AngleSharp
-
 open Perla
-open Perla.Types
-open Perla.Units
-open Perla.Server
-open Perla.Build
-open Perla.Logger
-open Perla.FileSystem
-open Perla.VirtualFs
-open Perla.Esbuild
-open Perla.Fable
-open Perla.Json
-open Perla.Scaffolding
-open Perla.Configuration.Types
-open Perla.Configuration
-open Perla.Extensibility
-
-open Perla.Plugins
-open Perla.PackageManager
 open Perla.PackageManager.Types
+open Perla.Types
+open Perla.Handlers
 
-open Perla.Testing
+type Input with
 
-
-module CliOptions =
-  [<Struct; RequireQualifiedAccess>]
-  type ListFormat =
-    | HumanReadable
-    | TextOnly
-
-  type ServeOptions =
-    { port: int option
-      host: string option
-      mode: RunConfiguration option
-      ssl: bool option }
-
-  type BuildOptions =
-    { mode: RunConfiguration option
-      enablePreview: bool
-      enablePreloads: bool
-      rebuildImportMap: bool }
-
-  type SetupOptions =
-    { skipPrompts: bool
-      skipPlaywright: bool }
-
-  type SearchOptions = { package: string; page: int }
-
-  type ShowPackageOptions = { package: string }
-
-  type ListTemplatesOptions = { format: ListFormat }
-
-  type AddPackageOptions =
-    { package: string
-      version: string option
-      source: Provider option
-      mode: RunConfiguration option
-      alias: string option }
-
-  type RemovePackageOptions =
-    { package: string
-      alias: string option }
-
-  type ListPackagesOptions = { format: ListFormat }
-
-  type TemplateRepositoryOptions =
-    { fullRepositoryName: string
-      branch: string
-      yes: bool }
-
-  type ProjectOptions =
-    { projectName: string
-      byTemplateName: string option
-      byId: string option
-      byShortName: string option }
-
-  type RestoreOptions =
-    { source: Provider option
-      mode: RunConfiguration option }
-
-  type TestingOptions =
-    { browsers: Browser seq option
-      files: string seq option
-      skip: string seq option
-      watch: bool option
-      headless: bool option
-      browserMode: BrowserMode option }
-
-  type DescribeOptions =
-    { properties: string[] option
-      current: bool }
-
-open CliOptions
-
-
-[<RequireQualifiedAccess>]
-module Handlers =
-  open AngleSharp.Html.Parser
-  open Zio.FileSystems
-  open Zio
-
-  let private updateTemplate
-    (template: PerlaTemplateRepository)
-    (branch: string)
-    (context: StatusContext)
-    =
-    context.Status <-
-      $"Download and extracting template {template.ToFullNameWithBranch}"
-
-    Templates.Update({ template with branch = branch })
-
-  let private addTemplate
-    (user: string)
-    (repository: string)
-    (branch: string)
-    (context: StatusContext)
-    =
-    context.Status <-
-      $"Download and extracting template {user}/{repository}:{branch}"
-
-    Templates.Add(user, repository, branch)
-
-  let runListTemplates (options: ListTemplatesOptions) =
-    let results = Templates.ListRepositories()
-
-    match options.format with
-    | ListFormat.HumanReadable ->
-      let table =
-        Table()
-          .AddColumns(
-            [| "Name"
-               "Templates"
-               "Template Branch"
-               "Last Update"
-               "Location" |]
-          )
-
-      for column in table.Columns do
-        column.Alignment <- Justify.Center
-
-      for result in results do
-        let printedDate =
-          result.updatedAt
-          |> Option.ofNullable
-          |> Option.defaultValue result.createdAt
-          |> (fun x -> x.ToShortDateString())
-
-        let children =
-          let names =
-            let basePath =
-              FileSystem.PathForTemplate(
-                result.username,
-                result.repository,
-                result.branch
-              )
-
-            DirectoryInfo(basePath).EnumerateDirectories()
-            |> Seq.map (fun d -> $"[green]{d.Name}[/]")
-
-          String.Join("\n", names) |> Markup
-
-        let path =
-          TextPath(
-            UMX.untag result.path,
-            LeafStyle = Style(Color.Green),
-            StemStyle = Style(Color.Yellow),
-            SeparatorStyle = Style(Color.Blue)
-          )
-
-        table.AddRow(
-          Markup($"[yellow]{result.ToFullName}[/]"),
-          children,
-          Markup(result.branch),
-          Markup(printedDate),
-          path
-        )
-        |> ignore
-
-      AnsiConsole.Write table
-      0
-    | ListFormat.TextOnly ->
-      for result in results do
-        Logger.log
-          $"[bold green]{result.ToFullName}[/]:[bold yellow]{result.branch}[/]"
-
-        let path = TextPath(UMX.untag result.path).StemColor(Color.Blue)
-        AnsiConsole.Write path
-
-      0
-
-  let runAddTemplate (opts: TemplateRepositoryOptions) =
-    task {
-      let autoContinue = opts.yes
-
-      let mutable chosen = parseFullRepositoryName opts.fullRepositoryName
-
-      while chosen |> ValueOption.isNone do
-        chosen <-
-          AnsiConsole.Ask(
-            "that doesn't feel right, please tell us the  username/repository:branch github repository to look for templates"
-          )
-          |> parseFullRepositoryName
-
-        match chosen with
-        | ValueNone -> ()
-        | parsed -> chosen <- parsed
-
-      let username, repository, _ = chosen.Value
-
-      let template =
-        TemplateSearchKind.FullName(username, repository) |> Templates.FindOne
-
-      match template, autoContinue with
-      | Some template, true ->
-        match!
-          Logger.spinner (
-            "Updating Templates",
-            updateTemplate template opts.branch
-          )
-        with
-        | true ->
-          Logger.log
-            $"{opts.fullRepositoryName} - {opts.branch} updated correctly"
-
-          return 0
-        | false ->
-          Logger.log
-            $"{opts.fullRepositoryName} - {opts.branch} was not updated"
-
-          return 1
-      | Some template, false ->
-        let prompt =
-          SelectionPrompt<string>(
-            Title =
-              $"\"{opts.fullRepositoryName}\" already exists, Do you want to update it?"
-          )
-            .AddChoices([ "Yes"; "No" ])
-
-        match AnsiConsole.Prompt(prompt) with
-        | "Yes" ->
-          match!
-            Logger.spinner (
-              "Updating Templates",
-              updateTemplate template opts.branch
-            )
-          with
-          | true ->
-            Logger.log
-              $"{opts.fullRepositoryName} - {opts.branch} updated correctly"
-
-            return 0
-          | false ->
-            Logger.log
-              $"{opts.fullRepositoryName} - {opts.branch} was not updated"
-
-            return 1
-        | _ ->
-          Logger.log $"Template {template.ToFullNameWithBranch} was not updated"
-
-          return 0
-      | None, _ ->
-
-        let! tplId =
-          Logger.spinner (
-            "Adding new templates",
-            addTemplate username repository opts.branch
-          )
-
-        match Templates.FindOne(TemplateSearchKind.Id tplId) with
-        | Some template ->
-          Logger.log $"Successfully added {template.ToFullNameWithBranch}"
-
-          let path =
-            TextPath(
-              UMX.untag template.path,
-              LeafStyle = Style(Color.Green),
-              StemStyle = Style(Color.Yellow),
-              SeparatorStyle = Style(Color.Blue)
-            )
-
-          AnsiConsole.Write("Template at path: ")
-          AnsiConsole.Write(path)
-          return 0
-        | None ->
-          Logger.log
-            $"Template may have been downloaded but for some reason we can't find it, this is likely a bug"
-
-          return 1
-
-    }
-
-  type FoundTemplate =
-    | Repository of PerlaTemplateRepository
-    | Existing of TemplateItem
-
-  type TemplateNotFoundCases =
-    | NoQueryParams
-    | ParentTemplateNotFound
-    | ChildTemplateNotFound
-
-  let runNew
+  static member OptionWithStrings
     (
-      opts: ProjectOptions,
-      cancellationToken: CancellationToken
-    ) : Task<int> =
-    Logger.log "Creating new project..."
-    let mutable mentionQuickCommand = false
-
-    let inline byId () =
-      opts.byId
-      |> Option.map UMX.tag<TemplateGroup>
-      |> Option.map (QuickAccessSearch.Group)
-
-    let inline byTemplateName () =
-      opts.byTemplateName |> Option.map (QuickAccessSearch.Name)
-
-    let queryParam =
-      opts.byShortName
-      |> Option.map (QuickAccessSearch.ShortName)
-      |> Option.orElseWith byId
-      |> Option.orElseWith byTemplateName
-
-    let foundRepo =
-      result {
-        let! query = queryParam |> Result.requireSome NoQueryParams
-
-        match query with
-        | QuickAccessSearch.Name name ->
-          let user, template, child = getTemplateAndChild name
-
-          let! found =
-            (match user, child with
-             | Some user, _ ->
-               Templates.FindOne(TemplateSearchKind.FullName(user, template))
-             | None, _ ->
-               Templates.FindOne(TemplateSearchKind.Repository template))
-            |> Result.requireSome ParentTemplateNotFound
-
-          return Repository found
-        | others ->
-          let! found =
-            Templates.FindTemplateItems(others)
-            |> Result.requireHead ChildTemplateNotFound
-
-          return Existing found
-      }
-
-    let inline TemplateItemPromptConverter (item: TemplateItem) =
-      let description =
-        item.description |> Option.defaultValue "No description provided."
-
-      $"{item.name} - {item.shortName}: {description[0..30]}"
-
-    let inline TemplateConfigPromptConverter (item: TemplateConfigurationItem) =
-      $"{item.name} - {item.shortName}: {item.description[0..30]}"
-
-    let selectedItem =
-      match foundRepo with
-      | Ok(Repository repo) ->
-        mentionQuickCommand <- true
-
-        let selection =
-          SelectionPrompt(
-            Title = $"Available templates for {repo.name}",
-            Converter = TemplateConfigPromptConverter
-          )
-            .AddChoices(repo.templates)
-
-        task {
-          let! result =
-            selection.ShowAsync(AnsiConsole.Console, cancellationToken)
-
-          return
-            Templates.FindTemplateItems(QuickAccessSearch.Id result.childId)
-            |> List.tryHead
-        }
-      | Ok(Existing item) -> Task.FromResult(Some item)
-      | Error NoQueryParams ->
-        mentionQuickCommand <- true
-
-        let selection =
-          SelectionPrompt(
-            Title = "Welcome to Perla, please select a template to start with",
-            Converter = TemplateItemPromptConverter
-          )
-            .AddChoices(Templates.ListTemplateItems())
-
-        task {
-          try
-            let! result =
-              selection.ShowAsync(AnsiConsole.Console, cancellationToken)
-
-            return Some result
-          with :? TaskCanceledException ->
-            return None
-        }
-      | Error ChildTemplateNotFound
-      | Error ParentTemplateNotFound ->
-        if
-          AnsiConsole.Ask(
-            "We were not able to find the template you were looking for, Would you like to check the existing templates?",
-            false
-          )
-        then
-          mentionQuickCommand <- true
-
-          let selection =
-            SelectionPrompt(
-              Title = "Please select a template to start with",
-              Converter = TemplateItemPromptConverter
-            )
-              .AddChoices(Templates.ListTemplateItems())
-
-          task {
-            try
-              let! result =
-                selection.ShowAsync(AnsiConsole.Console, cancellationToken)
-
-              return Some result
-            with :? TaskCanceledException ->
-              return None
-          }
-        else
-          Task.FromResult None
-
-    task {
-      let! item = selectedItem
-
-      match item with
-      | Some item ->
-        let scriptContent =
-          Templates.GetTemplateScriptContent(TemplateScriptKind.Template item)
-          |> Option.orElseWith (fun () ->
-            option {
-              let! repo = Templates.FindOne(TemplateSearchKind.Id item.parent)
-
-              return!
-                TemplateScriptKind.Repository repo
-                |> Templates.GetTemplateScriptContent
-            })
-
-        let targetPath =
-          $"./{opts.projectName}" |> Path.GetFullPath |> UMX.tag<UserPath>
-
-        FileSystem.WriteTplRepositoryToDisk(
-          item.fullPath,
-          targetPath,
-          ?payload = scriptContent
-        )
-
-
-        if mentionQuickCommand then
-          Logger.log "This template has quick access commands:"
-
-          Logger.log (
-            $"[bold yellow]perla new <my-project-name> -t {item.shortName}[/]",
-            escape = false
-          )
-
-          Logger.log (
-            $"Next time you can run [bold yellow]perla new <my-project-name> -id {item.group}[/]",
-            escape = false
-          )
-
-        Logger.log
-          $"Project [yellow]{opts.projectName}[/] created successfully!"
-
-        return 0
-
-      | None ->
-        Logger.log "No selection was available..."
-
-        Logger.log
-          "please check for typos or run 'perla new <my-projectname>' to run the templating wizard"
-
-        return 0
-    }
-
-  let runSetup (options: SetupOptions) =
-    task {
-      Logger.log "Perla will set up the following resources:"
-      Logger.log "- Esbuild"
-      Logger.log "- Default Templates"
-
-      if not options.skipPlaywright then
-        Logger.log
-          "- Playwright browsers (required for the 'perla test' command)"
-      else
-        Logger.log "- Playwright browsers (skipped)"
-
-      Logger.log
-        "After that you should be able to run 'perla build' or 'perla new'"
-
-      do! FileSystem.SetupEsbuild(UMX.tag Constants.Esbuild_Version)
-      Logger.log ("[bold green]esbuild[/] has been setup!", escape = false)
-
-      match options.skipPrompts, options.skipPlaywright with
-      | true, true -> Logger.log ("Skipping Playwright setup")
-      | true, false -> Testing.SetupPlaywright()
-      | false, true -> Logger.log ("Skipping Playwright setup")
-      | false, false ->
-        if
-          AnsiConsole.Confirm(
-            "Install Playwright browsers? (required for 'perla test' command)",
-            false
-          )
-        then
-          Testing.SetupPlaywright()
-        else
-          Logger.log ("Skipping Playwright setup")
-
-      if options.skipPrompts then
-        let username, repository, branch =
-          PerlaTemplateRepository.DefaultTemplatesRepository
-
-        match
-          TemplateSearchKind.FullName(username, repository) |> Templates.FindOne
-        with
-        | Some template ->
-          Logger.log
-            $"{template.ToFullName} is already set up, updating from {template.branch}"
-
-
-          let! result = Templates.Update(template)
-
-          if not result then
-            Logger.log (
-              "We were unable to update the existing [bold red]templates[/].",
-              escape = false
-            )
-
-            return 1
-          else
-            runListTemplates { format = ListFormat.HumanReadable } |> ignore
-
-            Logger.log (
-              "[bold yellow]perla[/] [bold blue]new [/] [bold green]perla-templates/<TEMPLATE_NAME>[/] [bold blue] <PROJECT_NAME>[/]",
-              escape = false
-            )
-
-            Logger.log "Feel  free to create a new perla project"
-            return 0
-        | None ->
-          let! _ =
-            Logger.spinner (
-              "Adding default templates",
-              addTemplate username repository branch
-            )
-
-          runListTemplates { format = ListFormat.HumanReadable } |> ignore
-
-          Logger.log (
-            "[bold yellow]perla[/] [bold blue]new [/] [bold green]perla-templates/<TEMPLATE_NAME>[/] [bold blue] <PROJECT_NAME>[/]",
-            escape = false
-          )
-
-          return 0
-      else if AnsiConsole.Confirm("Add default templates?", false) then
-        let username, repository, branch =
-          PerlaTemplateRepository.DefaultTemplatesRepository
-
-        match
-          TemplateSearchKind.FullName(username, repository) |> Templates.FindOne
-        with
-        | Some template ->
-          Logger.log
-            $"{template.ToFullName} is already set up, updating from {template.branch}"
-
-
-          let! result = Templates.Update(template)
-
-          if not (Ok result) then
-            Logger.log (
-              "We were unable to update the existing [bold red]templates[/].",
-              escape = false
-            )
-
-            return 1
-          else
-            runListTemplates { format = ListFormat.HumanReadable } |> ignore
-
-            Logger.log (
-              "[bold yellow]perla[/] [bold blue]new [/] [bold green]perla-templates/<TEMPLATE_NAME>[/] [bold blue] <PROJECT_NAME>[/]",
-              escape = false
-            )
-
-            Logger.log "Feel  free to create a new perla project"
-            return 0
-        | None ->
-          let! _ =
-            Logger.spinner (
-              "Adding default templates",
-              addTemplate username repository branch
-            )
-
-          runListTemplates { format = ListFormat.HumanReadable } |> ignore
-
-          Logger.log (
-            "[bold yellow]perla[/] [bold blue]new [/] [bold green]perla-templates/<TEMPLATE_NAME>[/] [bold blue] <PROJECT_NAME>[/]",
-            escape = false
-          )
-
-          return 0
-      else
-        Logger.log "Skip installing templates"
-        return 0
-    }
-
-  let runSearch (options: SearchOptions) =
-    task {
-      do! Dependencies.Search(options.package, options.page)
-      return 0
-    }
-
-  let runShow (options: ShowPackageOptions) =
-    task {
-      do! Dependencies.Show(options.package)
-      return 0
-    }
-
-  let runList (options: ListPackagesOptions) =
-    task {
-      let config = ConfigurationManager.CurrentConfig
-
-      match options.format with
-      | ListFormat.HumanReadable ->
-        Logger.log (
-          "[bold green]Installed packages[/] [yellow](alias: packageName@version)[/]\n",
-          escape = false
-        )
-
-        let prodTable =
-          dependencyTable (config.dependencies, "Production Dependencies")
-
-        let devTable =
-          dependencyTable (config.devDependencies, "Development Dependencies")
-
-        AnsiConsole.Write(prodTable)
-        AnsiConsole.WriteLine()
-        AnsiConsole.Write(devTable)
-
-      | ListFormat.TextOnly ->
-        let inline aliasDependency (dep: Dependency) =
-          let name =
-            match dep.alias with
-            | Some alias -> $"{alias}:{dep.name}"
-            | None -> dep.name
-
-          name, dep.version
-
-        let depsMap =
-          config.dependencies |> Seq.map aliasDependency |> Map.ofSeq
-
-        let devDepsMap =
-          config.devDependencies |> Seq.map aliasDependency |> Map.ofSeq
-
-        {| dependencies = depsMap
-           devDependencies = devDepsMap |}
-        |> Json.ToText
-        |> AnsiConsole.Write
-
-      return 0
-    }
-
-  let runRemoveTemplate (name: string) =
-    let deleteOperation =
-      option {
-        let! username, repository, _ = parseFullRepositoryName name
-
-        return
-          Templates.Delete(TemplateSearchKind.FullName(username, repository))
-      }
-
-    match deleteOperation with
-    | Some true ->
-      Logger.log (
-        $"[bold yellow]{name}[/] deleted from repositories.",
-        escape = false
-      )
-
-      0
-    | Some false ->
-      Logger.log (
-        $"[bold red]{name}[/] could not be deleted from repositories.",
-        escape = false
-      )
-
-      0
-    | None ->
-      Logger.log (
-        $"[bold red]{name}[/] was not found in the repository list.",
-        escape = false
-      )
-
-      1
-
-  let runUpdateTemplate (opts: TemplateRepositoryOptions) =
-    task {
-      match parseFullRepositoryName opts.fullRepositoryName with
-      | ValueSome(username, repository, branch) ->
-        match
-          Templates.FindOne(TemplateSearchKind.FullName(username, repository))
-        with
-        | Some template ->
-          let branch =
-            if String.IsNullOrWhiteSpace branch then
-              opts.branch
-            else
-              branch
-
-          match!
-            Logger.spinner ("Updating Template", updateTemplate template branch)
-          with
-          | Ok true ->
-            Logger.log (
-              $"[bold green]{opts.fullRepositoryName}[/] - [yellow]{branch}[/] updated correctly",
-              escape = false
-            )
-
-            return 0
-          | _ ->
-            Logger.log (
-              $"[bold red]{opts.fullRepositoryName}[/] - [yellow]{branch}[/] failed to update",
-              escape = false
-            )
-
-            return 1
-        | None ->
-          Logger.log (
-            $"[bold red]{opts.fullRepositoryName}[/] - [yellow]{branch}[/] failed to update",
-            escape = false
-          )
-
-          return 1
-      | ValueNone ->
-        Logger.log (
-          $"[bold red]{opts.fullRepositoryName}[/] Was not found in the templates",
-          escape = false
-        )
-
-        return 1
-
-    }
-
-  let runRemove (options: RemovePackageOptions) =
-    task {
-      let name = options.package
-      Logger.log ($"Removing: [red]{name}[/]", escape = false)
-      let config = ConfigurationManager.CurrentConfig
-
-      let map = FileSystem.GetImportMap()
-
-      let dependencies, devDependencies =
-        let deps, devDeps =
-          Dependencies.LocateDependenciesFromMapAndConfig(
-            map,
-            { config with
-                dependencies =
-                  config.dependencies |> Seq.filter (fun d -> d.name <> name)
-                devDependencies =
-                  config.devDependencies |> Seq.filter (fun d -> d.name <> name) }
-          )
-
-        deps, devDeps
-
-      ConfigurationManager.WriteFieldsToFile(
-        [ PerlaWritableField.Dependencies dependencies
-          PerlaWritableField.DevDependencies devDependencies ]
-      )
-
-      let packages =
-        match config.runConfiguration with
-        | RunConfiguration.Production ->
-          dependencies |> Seq.map (fun f -> f.AsVersionedString)
-        | RunConfiguration.Development ->
-          [ yield! dependencies; yield! devDependencies ]
-          |> Seq.map (fun f -> f.AsVersionedString)
-
-      match!
-        Dependencies.Restore(
-          packages,
-          Provider.Jspm,
-          runConfig = config.runConfiguration
-        )
-      with
-      | Ok map ->
-        FileSystem.WriteImportMap(map) |> ignore
-        return 0
-      | Error err ->
-        Logger.log $"[bold red]{err}[/]"
-        return 1
-    }
-
-  let runAdd (options: AddPackageOptions) =
-    task {
-      ConfigurationManager.UpdateFromCliArgs(
-        ?runConfig = options.mode,
-        ?provider = options.source
-      )
-
-      let config = ConfigurationManager.CurrentConfig
-      let package, packageVersion = parsePackageName options.package
-
-      match options.alias with
-      | Some _ ->
-        Logger.log (
-          $"[bold yellow]Aliases management will change in the future, they will be ignored if this warning appears[/]",
-          escape = false
-        )
-      | None -> ()
-
-      let version =
-        match packageVersion with
-        | Some version -> $"@{version}"
-        | None -> ""
-
-      let importMap = FileSystem.GetImportMap()
-      Logger.log "Updating Import Map..."
-
-      let! map =
-        Logger.spinner (
-          $"Adding: [bold yellow]{package}{version}[/]",
-          Dependencies.Add(
-            $"{package}{version}",
-            importMap,
-            provider = config.provider,
-            runConfig = config.runConfiguration
-          )
-        )
-
-      match map with
-      | Ok map ->
-        let newDep =
-          { name = package
-            version = packageVersion
-            alias = options.alias }
-
-        let dependencies, devDependencies =
-          let config =
-            match config.runConfiguration with
-            | RunConfiguration.Development ->
-              { config with
-                  devDependencies = [ yield! config.devDependencies; newDep ] }
-            | RunConfiguration.Production ->
-              { config with
-                  dependencies = [ yield! config.dependencies; newDep ] }
-
-          let deps, devDeps =
-            Dependencies.LocateDependenciesFromMapAndConfig(map, config)
-
-          PerlaWritableField.Dependencies deps,
-          PerlaWritableField.DevDependencies devDeps
-
-        ConfigurationManager.WriteFieldsToFile(
-          [ dependencies; devDependencies ]
-        )
-
-        FileSystem.WriteImportMap(map) |> ignore
-        return 0
-      | Error err ->
-        Logger.log ($"[bold red]{err}[/]", escape = false)
-        return 1
-    }
-
-  let runRestore (options: RestoreOptions) =
-    task {
-      ConfigurationManager.UpdateFromCliArgs(
-        ?runConfig = options.mode,
-        ?provider = options.source
-      )
-
-      let config = ConfigurationManager.CurrentConfig
-
-      Logger.log "Regenerating import map..."
-
-      let packages =
-        [ yield! config.dependencies
-          match config.runConfiguration with
-          | RunConfiguration.Development -> yield! config.devDependencies
-          | RunConfiguration.Production -> () ]
-        |> List.map (fun d -> d.AsVersionedString)
-        // deduplicate repeated strings
-        |> set
-
-      match!
-        Logger.spinner (
-          "Fetching dependencies...",
-          Dependencies.Restore(packages, provider = config.provider)
-        )
-      with
-      | Ok response -> FileSystem.WriteImportMap(response) |> ignore
-      | Error err ->
-        Logger.log $"An error happened restoring the import map:\n{err}"
-
-      return 0
-    }
-
-  let maybeFable (config: PerlaConfig, cancel: CancellationToken) =
-    task {
-      match config.fable with
-      | Some fable -> do! Fable.Start(fable, cancellationToken = cancel) :> Task
-      | None ->
-        Logger.log (
-          "No Fable configuration provided, skipping fable",
-          target = PrefixKind.Build
-        )
-    }
-
-  let runBuild (cancel: CancellationToken, args: BuildOptions) =
-    task {
-      FileSystem.GetDotEnvFilePaths() |> Env.LoadEnvFiles
-
-      ConfigurationManager.UpdateFromCliArgs(?runConfig = args.mode)
-      let config = ConfigurationManager.CurrentConfig
-
-      do! maybeFable (config, cancel)
-
-      if not <| File.Exists($"{FileSystem.EsbuildBinaryPath}") then
-        do! FileSystem.SetupEsbuild(config.esbuild.version, cancel)
-
-      let outDir = UMX.untag config.build.outDir
-
-      try
-        Directory.Delete(outDir, true)
-        Directory.CreateDirectory(outDir) |> ignore
-      with _ ->
-        ()
-
-      PluginRegistry.LoadPlugins(config.esbuild)
-
-      do!
-        Logger.spinner (
-          "Mounting Virtual File System",
-          VirtualFileSystem.Mount config
-        )
-
-      let tempDirectory = VirtualFileSystem.CopyToDisk() |> UMX.tag<SystemPath>
-
-      Logger.log (
-        $"Copying Processed files to {tempDirectory}",
-        target = PrefixKind.Build
-      )
-
-      let externals = Build.GetExternals(config)
-
-      let index = FileSystem.IndexFile(config.index)
-
-      use browserCtx = new BrowsingContext()
-
-      let parser = browserCtx.GetService<IHtmlParser>()
-
-      let document = parser.ParseDocument index
-
-      use fs = new PhysicalFileSystem()
-
-      let tmp = UMX.untag tempDirectory |> fs.ConvertPathFromInternal
-
-      let css, js = Build.GetEntryPoints(document)
-
-      let runEsbuild =
-        Task.WhenAll(
-          backgroundTask {
-            for css in css do
-              let path =
-                UPath.Combine(tmp, UMX.untag css) |> fs.ConvertPathToInternal
-
-              let targetPath =
-                Path.Combine(UMX.untag config.build.outDir, UMX.untag css)
-                |> Path.GetDirectoryName
-                |> UMX.tag<SystemPath>
-
-              let tsk =
-                Esbuild
-                  .ProcessCss(path, config.esbuild, targetPath)
-                  .ExecuteAsync(cancel)
-
-              do! tsk.Task :> Task
-          },
-
-          backgroundTask {
-            for js in js do
-              let path =
-                UPath.Combine(tmp, UMX.untag js) |> fs.ConvertPathToInternal
-
-              let targetPath =
-                Path.Combine(UMX.untag config.build.outDir, UMX.untag js)
-                |> Path.GetDirectoryName
-                |> UMX.tag<SystemPath>
-
-              let tsk =
-                Esbuild
-                  .ProcessJS(path, config.esbuild, targetPath, externals)
-                  .ExecuteAsync(cancel)
-
-              do! tsk.Task :> Task
-          }
-        )
-
-      do! Logger.spinner ("Transpiling CSS and JS Files", runEsbuild) :> Task
-
-      let css =
-        [ yield! css
-          yield!
-            js
-            |> Seq.map (fun p ->
-              Path.ChangeExtension(UMX.untag p, ".css") |> UMX.tag) ]
-
-
-      let outDir =
-        config.build.outDir
-        |> UMX.untag
-        |> Path.GetFullPath
-        |> fs.ConvertPathFromInternal
-
-      // copy any glob files
-      Build.CopyGlobs(config.build, tempDirectory)
-
-      // copy any root files
-      fs.EnumerateFileEntries(tmp, "*.*", SearchOption.TopDirectoryOnly)
-      |> Seq.iter (fun file ->
-        file.CopyTo(UPath.Combine(outDir, file.Name), true) |> ignore)
-
-      let indexContent =
-        Build.GetIndexFile(document, css, js, FileSystem.GetImportMap())
-      // Always copy the index file at the end to avoid
-      // clashing with any index.html file in the root of the virtual file system
-      fs.WriteAllText(UPath.Combine(outDir, "index.html"), indexContent)
-
-      Logger.log $"Cleaning up temp dir {tempDirectory}"
-
-      try
-        Directory.Delete(UMX.untag tempDirectory, true)
-      with ex ->
-        Logger.log ($"Failed to delete {tempDirectory}", ex = ex)
-
-      if config.build.emitEnvFile then
-        Logger.log "Writing Env File"
-        Build.EmitEnvFile(config)
-
-      if args.enablePreview then
-        let app = Server.GetStaticServer(config)
-        do! app.StartAsync(cancel)
-
-        app.Urls
-        |> Seq.iter (fun url ->
-          Logger.log ($"Listening at: {url}", target = Logger.Serve))
-
-        while not cancel.IsCancellationRequested do
-          do! Async.Sleep(1000)
-
-        do! app.StopAsync(cancel)
-
-      return 0
-    }
-
-  let private firstCompileFinished
-    isWatch
-    (observable: IObservable<FableEvent>)
-    =
-    observable
-    |> Observable.choose (function
-      | FableEvent.WaitingForChanges -> Some()
-      | _ -> None)
-    |> (fun obs ->
-      if isWatch then
-        Observable.first obs
-      else
-        Observable.takeLast 1 obs)
-    |> AsyncSeq.ofObservableBuffered
-    |> AsyncSeq.iter ignore
-
-  let private getFileChanges
-    (
-      index: string,
-      mountDirectories,
-      perlaFilesChanges,
-      plugins: string list
+      aliases: string seq,
+      ?values: string seq,
+      ?defaultValue: string,
+      ?description
     ) =
-    let perlaFilesChanges =
-      perlaFilesChanges
-      |> Observable.map (fun event ->
-        let name, path, extension =
-          match event with
-          | PerlaFileChange.Index ->
-            (Path.GetFileName index, Path.GetFullPath index, ".html")
-          | PerlaFileChange.PerlaConfig ->
-            (Constants.PerlaConfigName,
-             UMX.untag FileSystem.PerlaConfigPath,
-             ".jsonc")
-          | PerlaFileChange.ImportMap ->
-            (Constants.ImportMapName,
-             UMX.untag (FileSystem.GetConfigPath Constants.ImportMapName None),
-             ".importmap")
-
-        { serverPath = UMX.tag "/"
-          userPath = UMX.tag "/"
-          oldPath = None
-          oldName = None
-          changeType = ChangeKind.Changed
-          path = UMX.tag path
-          name = UMX.tag name },
-        { content = ""; extension = extension })
-
-    VirtualFileSystem.GetFileChangeStream mountDirectories
-    |> VirtualFileSystem.ApplyVirtualOperations plugins
-    |> Observable.merge perlaFilesChanges
-
-  let runServe (cancel: CancellationToken, options: ServeOptions) =
-    task {
-      FileSystem.GetDotEnvFilePaths() |> Env.LoadEnvFiles
-
-      let cliArgs =
-        [ match options.port with
-          | Some port -> DevServerField.Port port
-          | None -> ()
-          match options.host with
-          | Some host -> DevServerField.Host host
-          | None -> ()
-          match options.ssl with
-          | Some ssl -> DevServerField.UseSSL ssl
-          | None -> ()
-          // Don't minify sources in dev mode
-          DevServerField.MinifySources false ]
-
-      ConfigurationManager.UpdateFromCliArgs(
-        ?runConfig = options.mode,
-        serverOptions = cliArgs
+    let option =
+      Opt<string option>(
+        aliases |> Array.ofSeq,
+        getDefaultValue = (fun _ -> defaultValue),
+        ?description = description
       )
 
+    match values with
+    | Some values -> option.FromAmong(values |> Array.ofSeq)
+    | None -> option
+    |> HandlerInput.OfOption
 
-      let config = ConfigurationManager.CurrentConfig
-
-      let fableEvents =
-        match config.fable with
-        | Some fable -> Fable.Observe(fable, cancellationToken = cancel)
-        | None ->
-          let sub = Subject.replay
-          sub.OnNext(FableEvent.WaitingForChanges)
-          sub
-
-      use _ =
-        fableEvents
-        |> Observable.subscribeSafe (fun events ->
-          match events with
-          | FableEvent.Log msg -> Logger.log (msg.EscapeMarkup())
-          | FableEvent.ErrLog msg ->
-            Logger.log $"[bold red]{msg.EscapeMarkup()}[/]"
-          | FableEvent.WaitingForChanges -> ())
-
-      do! firstCompileFinished true fableEvents
-
-      do! FileSystem.SetupEsbuild(config.esbuild.version, cancel)
-
-      PluginRegistry.LoadPlugins(config.esbuild)
-
-      do! VirtualFileSystem.Mount(config)
-
-      let perlaChanges =
-        FileSystem.ObservePerlaFiles(UMX.untag config.index, cancel)
-
-      let fileChanges =
-        getFileChanges (
-          UMX.untag config.index,
-          config.mountDirectories,
-          perlaChanges,
-          config.plugins
-        )
-
-      // TODO: Grab these from esbuild
-      let compilerErrors = Observable.empty
-
-      let mutable app = Server.GetServerApp(config, fileChanges, compilerErrors)
-      do! app.StartAsync(cancel)
-
-      app.Urls
-      |> Seq.iter (fun url ->
-        Logger.log ($"Listening at: {url}", target = Logger.Serve))
-
-      perlaChanges
-      |> Observable.throttle (TimeSpan.FromMilliseconds(500.))
-      |> Observable.choose (function
-        | PerlaFileChange.PerlaConfig -> Some()
-        | _ -> None)
-      |> Observable.map (fun _ -> app.StopAsync() |> Async.AwaitTask)
-      |> Observable.switchAsync
-      |> Observable.add (fun _ ->
-        ConfigurationManager.UpdateFromFile()
-        app <- Server.GetServerApp(config, fileChanges, compilerErrors)
-        app.StartAsync(cancel) |> ignore)
-
-      while not cancel.IsCancellationRequested do
-        do! Async.Sleep(TimeSpan.FromSeconds(1.))
-
-      return 0
-    }
-
-  /// set esbuild, playwright and import map dependencies in parallel
-  /// as these are not overlaping and should save time
-  let setupDependencies (config, cancel) =
-    task {
-      let! results =
-        [ task {
-            do Testing.SetupPlaywright()
-            return None
-          }
-          task {
-            do! FileSystem.SetupEsbuild(config.esbuild.version, cancel)
-            return None
-          }
-          task {
-            let! result =
-              Logger.spinner (
-                "Resolving Static dependencies and import map...",
-                Dependencies.GetMapAndDependencies(
-                  [ yield! config.dependencies; yield! config.devDependencies ]
-                  |> Seq.map (fun d -> d.AsVersionedString),
-                  config.provider
-                )
-              )
-
-            return
-              result
-              |> Result.defaultWith (fun _ ->
-                (Seq.empty, FileSystem.GetImportMap()))
-              |> Some
-          } ]
-        |> Task.WhenAll
-
-      return results[2].Value
-    }
-
-  let runTesting (cancel: CancellationToken, options: TestingOptions) =
-    task {
-      FileSystem.GetDotEnvFilePaths() |> Env.LoadEnvFiles
-
-      ConfigurationManager.UpdateFromCliArgs(
-        testingOptions =
-          [ match options.browsers with
-            | Some value -> TestingField.Browsers value
-            | None -> ()
-            match options.files with
-            | Some value -> TestingField.Includes value
-            | None -> ()
-            match options.skip with
-            | Some value -> TestingField.Excludes value
-            | None -> ()
-            match options.watch with
-            | Some value -> TestingField.Watch value
-            | None -> ()
-            match options.headless with
-            | Some value -> TestingField.Headless value
-            | None -> ()
-            match options.browserMode with
-            | Some value -> TestingField.BrowserMode value
-            | None -> () ]
+  static member MultipleStrings
+    (
+      name: string,
+      ?values: string seq,
+      ?description
+    ) =
+    let option =
+      Option<string[] option>(
+        name = name,
+        ?description = description,
+        IsRequired = false,
+        AllowMultipleArgumentsPerToken = true,
+        parseArgument =
+          (fun result ->
+            match result.Tokens |> Seq.toArray with
+            | [||] -> None
+            | others -> Some(others |> Array.map (fun token -> token.Value)))
       )
 
-      let config =
-        { ConfigurationManager.CurrentConfig with
-            mountDirectories =
-              ConfigurationManager.CurrentConfig.mountDirectories
-              |> Map.add
-                (UMX.tag<ServerUrl> "/tests")
-                (UMX.tag<UserPath> "./tests") }
+    match values with
+    | Some values -> option.FromAmong(values |> Array.ofSeq)
+    | None -> option
+    |> HandlerInput.OfOption
 
-      let isWatch = config.testing.watch
+  static member ArgumentWithStrings
+    (
+      name: string,
+      ?values: string seq,
+      ?defaultValue: string,
+      ?description
+    ) =
+    let arg =
+      Arg<string option>(
+        name,
+        getDefaultValue = (fun _ -> defaultValue),
+        ?description = description
+      )
 
-      let! dependencies = setupDependencies (config, cancel)
+    match values with
+    | Some values -> arg.FromAmong(values |> Array.ofSeq)
+    | None -> arg
+    |> HandlerInput.OfArgument
 
-      let fableEvents =
-        match config.testing.fable with
-        | Some fable -> Fable.Observe(fable, isWatch)
-        | None -> Observable.single FableEvent.WaitingForChanges
+  static member ArgumentMaybe(name: string, ?values: string seq, ?description) =
+    let arg =
+      Arg<string option>(
+        name,
+        parse =
+          (fun argResult ->
+            match argResult.Tokens |> Seq.toList with
+            | [] -> None
+            | [ token ] -> Some token.Value
+            | _ :: _ ->
+              failwith "F# Option can only be used with a single argument."),
+        ?description = description
+      )
 
-      fableEvents
-      |> Observable.add (fun events ->
-        match events with
-        | FableEvent.Log msg -> Logger.log (msg.EscapeMarkup())
-        | FableEvent.ErrLog msg ->
-          Logger.log $"[bold red]{msg.EscapeMarkup()}[/]"
-        | FableEvent.WaitingForChanges -> ())
-
-      do! firstCompileFinished isWatch fableEvents
-
-
-      PluginRegistry.LoadPlugins config.esbuild
-
-      do! VirtualFileSystem.Mount config
-
-      let perlaChanges =
-        FileSystem.ObservePerlaFiles(UMX.untag config.index, cancel)
-
-      let fileChanges =
-        getFileChanges (
-          UMX.untag config.index,
-          config.mountDirectories,
-          perlaChanges,
-          config.plugins
-        )
-      // TODO: Grab these from esbuild
-      let compilerErrors = Observable.empty
-
-      let config =
-        { config with
-            devServer =
-              { config.devServer with
-                  liveReload = isWatch } }
-
-      let events = Subject<TestEvent>.replay
-
-      let mutable app =
-        Server.GetTestingApp(
-          config,
-          dependencies,
-          events,
-          fileChanges,
-          compilerErrors,
-          config.testing.includes
-        )
-      // Keep this before initializing the server
-      // otherwise it will always say that the port is occupied
-      let http, _ =
-        Server.GetServerURLs
-          config.devServer.host
-          config.devServer.port
-          config.devServer.useSSL
-
-      do! app.StartAsync(cancel)
-
-      perlaChanges
-      |> Observable.choose (function
-        | PerlaFileChange.PerlaConfig -> Some()
-        | _ -> None)
-      |> Observable.map (fun _ -> app.StopAsync() |> Async.AwaitTask)
-      |> Observable.switchAsync
-      |> Observable.map (fun _ ->
-        ConfigurationManager.UpdateFromFile()
-        app <- Server.GetServerApp(config, fileChanges, compilerErrors)
-        app.StartAsync(cancel) |> Async.AwaitTask)
-      |> Observable.switchAsync
-      |> Observable.add ignore
+    match values with
+    | Some values -> arg.FromAmong(values |> Array.ofSeq)
+    | None -> arg
+    |> HandlerInput.OfArgument
 
 
-      use! pl = Playwright.CreateAsync()
+let runAsDev =
+  Input.OptionMaybe(
+    [ "--development"; "-d"; "--dev" ],
+    "Use Dev dependencies when running, defaults to false"
+  )
 
-
-      if not isWatch then
-        let browsers =
-          asyncSeq {
-            for browser in config.testing.browsers do
-              let! iBrowser =
-                Testing.GetBrowser(pl, browser, config.testing.headless)
-                |> Async.AwaitTask
-
-              browser, iBrowser
-          }
-
-        let runTest (browser, iBrowser) =
-          async {
-            let executor = Testing.GetExecutor(http, browser)
-            do! executor iBrowser |> Async.AwaitTask
-            do! iBrowser.CloseAsync() |> Async.AwaitTask
-            return! iBrowser.DisposeAsync().AsTask() |> Async.AwaitTask
-          }
-
-        match config.testing.browserMode with
-        | BrowserMode.Parallel ->
-          do!
-            Async.StartAsTask(
-              browsers |> AsyncSeq.iterAsyncParallel runTest,
-              cancellationToken = cancel
-            )
-        | BrowserMode.Sequential ->
-          do!
-            Async.StartAsTask(
-              browsers |> AsyncSeq.iterAsync runTest,
-              cancellationToken = cancel
-            )
-
-
-        events.OnCompleted()
-
-        events
-        |> Observable.toEnumerable
-        |> Seq.toList
-        |> Testing.BuildReport
-        |> Print.Report
-
-        return 0
-      else
-        let browser = config.testing.browsers |> Seq.head
-
-        let! iBrowser =
-          Testing.GetBrowser(
-            pl,
-            config.testing.browsers |> Seq.head,
-            config.testing.headless
-          )
-
-        let liveExecutor =
-          Testing.GetLiveExecutor(
-            http,
-            browser,
-            fileChanges |> Observable.map ignore
-          )
-
-        use _ = Testing.PrintReportLive events
-        let! pageReloads = liveExecutor iBrowser
-
-        use _ =
-          pageReloads
-          |> Observable.subscribeSafe (fun _ ->
-            Logger.log $"Live Reload: Page Reloaded After Change")
-
-        while not cancel.IsCancellationRequested do
-          do! Async.Sleep(TimeSpan.FromSeconds(1.))
-
-        events.OnCompleted()
-
-        events
-        |> Observable.toEnumerable
-        |> Seq.toList
-        |> Testing.BuildReport
-        |> Print.Report
-
-        return 0
-    }
-
-  let runDescribe (cancel: CancellationToken, options: DescribeOptions) =
-    task {
-      let { properties = props
-            current = current } =
-        options
-
-      let config = ConfigurationManager.CurrentConfig
-
-      let table = Table().AddColumn("Property")
-
-      AnsiConsole.Write(FigletText("Perla.json"))
-      let descriptions = FileSystem.DescriptionsFile
-
-      match props, current with
-      | Some props, true ->
-        table.AddColumns("Value", "Explanation") |> ignore
-
-        for prop in props do
-          let description =
-            descriptions.Value |> Map.tryFind prop |> Option.defaultValue ""
-
-          match prop with
-          | TopLevelProp prop ->
-            table.AddRow(
-              Text(prop),
-              config[prop] |> Option.defaultValue (Text ""),
-              Text(description)
-            )
-            |> ignore
-          | NestedProp props ->
-            table.AddRow(
-              Text(prop),
-              config[props] |> Option.defaultValue (Text ""),
-              Text(description)
-            )
-            |> ignore
-          | TripleNestedProp props ->
-            table.AddRow(
-              Text(prop),
-              config[props] |> Option.defaultValue (Text ""),
-              Text(description)
-            )
-            |> ignore
-          | InvalidPropPath ->
-            table.AddRow(prop, "", "This is not a valid property") |> ignore
-
-      | Some props, false ->
-        table.AddColumns("Description", "Default Value") |> ignore
-
-        for prop in props do
-          let description =
-            descriptions.Value |> Map.tryFind prop |> Option.defaultValue ""
-
-          match prop with
-          | TopLevelProp prop ->
-            table.AddRow(
-              Text(prop),
-              Text(description),
-              Defaults.PerlaConfig[prop] |> Option.defaultValue (Text "")
-            )
-            |> ignore
-          | NestedProp props ->
-            table.AddRow(
-              Text(prop),
-              Text(description),
-              Defaults.PerlaConfig[props] |> Option.defaultValue (Text "")
-            )
-            |> ignore
-          | TripleNestedProp props ->
-            table.AddRow(
-              Text(prop),
-              Text(description),
-              Defaults.PerlaConfig[props] |> Option.defaultValue (Text "")
-            )
-            |> ignore
-          | InvalidPropPath ->
-            table.AddRow(
-              Text(
-                prop,
-                Style(foreground = Color.Yellow, background = Color.Yellow)
-              ),
-              Text(""),
-              Text(
-                "This is not a valid property",
-                Style(foreground = Color.Yellow)
-              )
-            )
-            |> ignore
-
-      | None, false ->
-        table.AddColumn("Description") |> ignore
-
-        for KeyValue(key, value) in descriptions.Value do
-          table.AddRow(key, value) |> ignore
-      | None, true ->
-        table.AddColumns("Current Value", "Description") |> ignore
-
-        for KeyValue(key, description) in descriptions.Value do
-          match key with
-          | TopLevelProp prop ->
-            table.AddRow(
-              Text(prop),
-              Defaults.PerlaConfig[prop] |> Option.defaultValue (Text ""),
-              Text(description)
-            )
-            |> ignore
-          | NestedProp props ->
-            table.AddRow(
-              Text(key),
-              Defaults.PerlaConfig[props] |> Option.defaultValue (Text ""),
-              Text(description)
-            )
-            |> ignore
-          | TripleNestedProp props ->
-            table.AddRow(
-              Text(key),
-              Defaults.PerlaConfig[props] |> Option.defaultValue (Text ""),
-              Text(description)
-            )
-            |> ignore
-          | InvalidPropPath ->
-            table.AddRow(
-              Text(
-                key,
-                Style(foreground = Color.Yellow, background = Color.Yellow)
-              ),
-              Text(""),
-              Text(
-                "This is not a valid property",
-                Style(foreground = Color.Yellow)
-              )
-            )
-            |> ignore
-
-      table.Caption <-
-        TableTitle(
-          "For more information visit: https://perla-docs.web.app/#/v1/docs/reference/perla"
-        )
-
-      table.DoubleBorder() |> AnsiConsole.Write
-      return 0
-    }
-
-
-module Commands =
-
-  open FSharp.SystemCommandLine
-  open FSharp.SystemCommandLine.Aliases
-
-  [<AutoOpen>]
-  module Inputs =
-
-    type Input with
-
-      static member OptionWithStrings
-        (
-          aliases: string seq,
-          ?values: string seq,
-          ?defaultValue: string,
-          ?description
-        ) =
-        let option =
-          Opt<string option>(
-            aliases |> Array.ofSeq,
-            getDefaultValue = (fun _ -> defaultValue),
-            ?description = description
-          )
-
-        match values with
-        | Some values -> option.FromAmong(values |> Array.ofSeq)
-        | None -> option
-        |> HandlerInput.OfOption
-
-      static member MultipleStrings
-        (
-          name: string,
-          ?values: string seq,
-          ?description
-        ) =
-        let option =
-          Option<string[] option>(
-            name = name,
-            ?description = description,
-            IsRequired = false,
-            AllowMultipleArgumentsPerToken = true,
-            parseArgument =
-              (fun result ->
-                match result.Tokens |> Seq.toArray with
-                | [||] -> None
-                | others ->
-                  Some(others |> Array.map (fun token -> token.Value)))
-          )
-
-        match values with
-        | Some values -> option.FromAmong(values |> Array.ofSeq)
-        | None -> option
-        |> HandlerInput.OfOption
-
-      static member ArgumentWithStrings
-        (
-          name: string,
-          ?values: string seq,
-          ?defaultValue: string,
-          ?description
-        ) =
-        let arg =
-          Arg<string option>(
-            name,
-            getDefaultValue = (fun _ -> defaultValue),
-            ?description = description
-          )
-
-        match values with
-        | Some values -> arg.FromAmong(values |> Array.ofSeq)
-        | None -> arg
-        |> HandlerInput.OfArgument
-
-      static member ArgumentMaybe
-        (
-          name: string,
-          ?values: string seq,
-          ?description
-        ) =
-        let arg =
-          Arg<string option>(
-            name,
-            parse =
-              (fun argResult ->
-                match argResult.Tokens |> Seq.toList with
-                | [] -> None
-                | [ token ] -> Some token.Value
-                | _ :: _ ->
-                  failwith "F# Option can only be used with a single argument."),
-            ?description = description
-          )
-
-        match values with
-        | Some values -> arg.FromAmong(values |> Array.ofSeq)
-        | None -> arg
-        |> HandlerInput.OfArgument
-
-  let runAsDev =
+let Build =
+  let enablePreloads =
     Input.OptionMaybe(
-      [ "--development"; "-d"; "--dev" ],
-      "Use Dev dependencies when running, defaults to false"
+      [ "-epl"; "--enable-preload-links" ],
+      "enable adding modulepreload links in the final build"
     )
 
-  let Build =
-    let enablePreloads =
-      Input.OptionMaybe(
-        [ "-epl"; "--enable-preload-links" ],
-        "enable adding modulepreload links in the final build"
+  let rebuildImportMap =
+    Input.OptionMaybe(
+      [ "-rim"; "--rebuild-importmap" ],
+      "discards the current import map (and custom resolutions)
+       and generates a new one based on the dependencies listed in the config file."
+    )
+
+  let preview =
+    Input.OptionMaybe(
+      [ "-prev"; "--preview" ],
+      "discards the current import map (and custom resolutions)
+       and generates a new one based on the dependencies listed in the config file."
+    )
+
+  let buildArgs
+    (
+      context: InvocationContext,
+      runAsDev: bool option,
+      enablePreloads: bool option,
+      rebuildImportMap: bool option,
+      enablePreview: bool option
+    ) =
+    { mode =
+        runAsDev
+        |> Option.map (fun runAsDev ->
+          match runAsDev with
+          | true -> RunConfiguration.Development
+          | false -> RunConfiguration.Production)
+      enablePreloads = defaultArg enablePreloads true
+      rebuildImportMap = defaultArg rebuildImportMap false
+      enablePreview = defaultArg enablePreview false },
+    context.GetCancellationToken()
+
+  command "build" {
+    description "Builds the SPA application for distribution"
+    addAlias "b"
+    inputs (
+      Input.Context(),
+      runAsDev,
+      enablePreloads,
+      rebuildImportMap,
+      preview
+    )
+
+    setHandler (buildArgs >> Handlers.runBuild)
+  }
+
+let Serve =
+
+  let port =
+    Input.OptionMaybe<int>(
+      [ "--port"; "-p" ],
+      "Port where the application starts"
+    )
+
+  let host =
+    Input.OptionMaybe<string>(
+      [ "--host" ],
+      "network ip address where the application will run"
+    )
+
+  let ssl = Input.OptionMaybe<bool>([ "--ssl" ], "Run dev server with SSL")
+
+
+  let buildArgs
+    (
+      context: InvocationContext,
+      mode: bool option,
+      port: int option,
+      host: string option,
+      ssl: bool option
+    ) =
+    { mode =
+        mode
+        |> Option.map (fun runAsDev ->
+          match runAsDev with
+          | true -> RunConfiguration.Development
+          | false -> RunConfiguration.Production)
+      port = port
+      host = host
+      ssl = ssl },
+    context.GetCancellationToken()
+
+  let desc =
+    "Starts the development server and if fable projects are present it also takes care of it."
+
+  command "serve" {
+    description desc
+    addAliases ["s"; "start"]
+    inputs (Input.Context(), runAsDev, port, host, ssl)
+    setHandler (buildArgs >> Handlers.runServe)
+  }
+
+let Setup =
+  let skipPrompts =
+    Input.OptionMaybe<bool>(
+      [ "--skip-prompts"; "-y"; "--yes"; "-sp" ],
+      "Skip prompts"
+    )
+
+  let playwrightDeps =
+    Input.OptionMaybe<bool>(
+      [ "--skip-playwright" ],
+      "Skips installing playwright (defaults to true)"
+    )
+
+  let buildArgs
+    (
+      ctx: InvocationContext,
+      yes: bool option,
+      skipPlaywright: bool option
+    ) : SetupOptions * CancellationToken =
+    { skipPrompts = yes |> Option.defaultValue false
+      skipPlaywright = skipPlaywright |> Option.defaultValue true },
+    ctx.GetCancellationToken()
+
+
+  command "setup" {
+    description "Initialized a given directory or perla itself"
+    inputs (Input.Context(), skipPrompts, playwrightDeps)
+    setHandler (buildArgs >> Handlers.runSetup)
+  }
+
+let SearchPackage =
+  let package =
+    Input.OptionRequired(
+      "package",
+      "The package you want to search for in the Skypack api"
+    )
+
+  let page =
+    Input.OptionMaybe(
+      [| "--page"; "-p" |],
+      "change the page number in the search results"
+    )
+
+  let buildArgs
+    (
+      ctx: InvocationContext,
+      package: string,
+      page: int option
+    ) : SearchOptions * CancellationToken =
+    { package = package
+      page = page |> Option.defaultValue 1 },
+    ctx.GetCancellationToken()
+
+  command "search" {
+    description
+      "Search a package name in the Skypack api, this will bring potential results"
+
+    inputs (Input.Context(), package, page)
+    setHandler (buildArgs >> Handlers.runSearchPackage)
+  }
+
+let ShowPackage =
+  let package =
+    Input.Argument(
+      "package",
+      "The package you want to search for in the Skypack api"
+    )
+
+  let buildArgs
+    (
+      ctx: InvocationContext,
+      package: string
+    ) : ShowPackageOptions * CancellationToken =
+    { package = package }, ctx.GetCancellationToken()
+
+  command "show" {
+    description
+      "Shows information about a package if the name matches an existing one"
+
+    inputs (Input.Context(), package)
+    setHandler (buildArgs >> Handlers.runShowPackage)
+  }
+
+let RemovePackage =
+  let package =
+    Input.Argument(
+      "package",
+      "The package you want to search for in the Skypack api"
+    )
+
+  let alias =
+    Input.OptionMaybe(
+      [ "--alias"; "-a" ],
+      "the alias of the package if you added one"
+    )
+
+  let buildArgs
+    (
+      ctx: InvocationContext,
+      package: string,
+      alias: string option
+    ) : RemovePackageOptions * CancellationToken =
+    { package = package; alias = alias }, ctx.GetCancellationToken()
+
+  command "remove" {
+    description "removes a package from the "
+
+    inputs (Input.Context(), package, alias)
+    setHandler (buildArgs >> Handlers.runRemovePackage)
+  }
+
+let AddPackage =
+  let package =
+    Input.Argument(
+      "package",
+      "The package you want to search for in the skypack api"
+    )
+
+  let version =
+    let opt =
+      Aliases.Opt<string option>(
+        [| "-v"; "--version" |],
+        parseArgument =
+          (fun arg ->
+            arg.Tokens
+            |> Seq.tryHead
+            |> Option.map (fun token -> token.Value |> Option.ofObj)
+            |> Option.flatten)
       )
 
-    let rebuildImportMap =
-      Input.OptionMaybe(
-        [ "-rim"; "--rebuild-importmap" ],
-        "discards the current import map (and custom resolutions)
-         and generates a new one based on the dependencies listed in the config file."
-      )
+    opt |> HandlerInput.OfOption
 
-    let preview =
-      Input.OptionMaybe(
-        [ "-prev"; "--preview" ],
-        "discards the current import map (and custom resolutions)
-         and generates a new one based on the dependencies listed in the config file."
-      )
+  let source =
+    Input.OptionWithStrings(
+      [ "--source"; "-s" ],
+      [ "jspm"; "skypack"; "unpkg"; "jsdelivr"; "jspm.system" ],
+      "jspm",
+      "CDN that will be used to fetch dependencies from"
+    )
 
-    let buildArgs
-      (
-        context: InvocationContext,
-        runAsDev: bool option,
-        enablePreloads: bool option,
-        rebuildImportMap: bool option,
-        enablePreview: bool option
-      ) =
-      (context.GetCancellationToken(),
-       { mode =
-           runAsDev
-           |> Option.map (fun runAsDev ->
-             match runAsDev with
-             | true -> RunConfiguration.Development
-             | false -> RunConfiguration.Production)
-         enablePreloads = defaultArg enablePreloads true
-         rebuildImportMap = defaultArg rebuildImportMap false
-         enablePreview = defaultArg enablePreview false })
+  let dev =
+    Input.OptionMaybe(
+      [ "--dev"; "--development"; "-d" ],
+      "Adds this dependency to the dev dependencies"
+    )
 
-    command "build" {
-      description "Builds the SPA application for distribution"
+  let alias =
+    Input.OptionMaybe(
+      [ "--alias"; "-a" ],
+      "the alias of the package if you added one"
+    )
 
-      inputs (
-        Input.Context(),
-        runAsDev,
-        enablePreloads,
-        rebuildImportMap,
-        preview
-      )
+  let buildArgs
+    (
+      ctx: InvocationContext,
+      package: string,
+      version: string option,
+      source: string option,
+      dev: bool option,
+      alias: string option
+    ) : AddPackageOptions * CancellationToken =
+    { package = package
+      version = version
+      source = source |> Option.map Provider.FromString
+      mode =
+        dev
+        |> Option.map (fun dev ->
+          if dev then
+            RunConfiguration.Development
+          else
+            RunConfiguration.Production)
+      alias = alias },
+    ctx.GetCancellationToken()
 
-      setHandler (buildArgs >> Handlers.runBuild)
-    }
+  command "add" {
+    description
+      "Shows information about a package if the name matches an existing one"
+    addAlias "install"
+    inputs (Input.Context(), package, version, source, dev, alias)
+    setHandler (buildArgs >> Handlers.runAddPackage)
+  }
 
-  let Serve =
+let ListPackages =
 
-    let port =
-      Input.OptionMaybe<int>(
-        [ "--port"; "-p" ],
-        "Port where the application starts"
-      )
+  let asNpm =
+    Input.OptionMaybe(
+      [ "--npm"; "--as-package-json"; "-j" ],
+      "Show the packages simlar to npm's package.json"
+    )
 
-    let host =
-      Input.OptionMaybe<string>(
-        [ "--host" ],
-        "network ip address where the application will run"
-      )
+  let buildArgs (asNpm: bool option) : ListPackagesOptions =
+    { format =
+        asNpm
+        |> Option.map (fun asNpm ->
+          if asNpm then
+            ListFormat.TextOnly
+          else
+            ListFormat.HumanReadable)
+        |> Option.defaultValue ListFormat.HumanReadable }
 
-    let ssl = Input.OptionMaybe<bool>([ "--ssl" ], "Run dev server with SSL")
+  command "list" {
+    addAlias "ls"
+    description
+      "Lists the current dependencies in a table or an npm style json string"
 
+    inputs asNpm
+    setHandler (buildArgs >> Handlers.runListPackages)
+  }
 
-    let buildArgs
-      (
-        context: InvocationContext,
-        mode: bool option,
-        port: int option,
-        host: string option,
-        ssl: bool option
-      ) =
-      (context.GetCancellationToken(),
-       { mode =
-           mode
-           |> Option.map (fun runAsDev ->
-             match runAsDev with
-             | true -> RunConfiguration.Development
-             | false -> RunConfiguration.Production)
-         port = port
-         host = host
-         ssl = ssl })
+let RestoreImportMap =
+  let source =
+    Input.OptionWithStrings(
+      [ "--source"; "-s" ],
+      [ "jspm"; "skypack"; "unpkg"; "jsdelivr"; "jspm.system" ],
+      description = "CDN that will be used to fetch dependencies from"
+    )
 
-    let desc =
-      "Starts the development server and if fable projects are present it also takes care of it."
+  let mode =
+    Input.OptionWithStrings(
+      [ "--mode"; "-m" ],
+      [ "dev"; "development"; "prod"; "production" ],
+      description = "Restore Dependencies based on the mode to run"
+    )
 
-    command "serve" {
-      description desc
-      inputs (Input.Context(), runAsDev, port, host, ssl)
-      setHandler (buildArgs >> Handlers.runServe)
-    }
+  let buildArgs
+    (
+      ctx: InvocationContext,
+      source: string option,
+      mode: string option
+    ) : RestoreOptions * CancellationToken =
+    { source = source |> Option.map Provider.FromString
+      mode = mode |> Option.map RunConfiguration.FromString },
+    ctx.GetCancellationToken()
 
-  let Setup =
-    let skipPrompts =
-      Input.OptionMaybe<bool>(
-        [ "--skip-prompts"; "-y"; "--yes"; "-sp" ],
-        "Skip prompts"
-      )
+  command "regenerate" {
+    addAlias "restore"
+    description
+      "Restore the import map based on the selected mode, defaults to production"
 
-    let playwrightDeps =
-      Input.OptionMaybe<bool>(
-        [ "--skip-playwright" ],
-        "Skips installing playwright (defaults to true)"
-      )
+    inputs (Input.Context(), source, mode)
+    setHandler (buildArgs >> Handlers.runRestoreImportMap)
+  }
 
-    let buildArgs
-      (
-        yes: bool option,
-        skipPlaywright: bool option
-      ) : SetupOptions =
-      { skipPrompts = yes |> Option.defaultValue false
-        skipPlaywright = skipPlaywright |> Option.defaultValue true }
+let Template =
+  let repoName =
+    Input.Argument(
+      "templateRepositoryName",
+      "The User/repository name combination"
+    )
 
-    command "setup" {
-      description "Initialized a given directory or perla itself"
-      inputs (skipPrompts, playwrightDeps)
-      setHandler (buildArgs >> Handlers.runSetup)
-    }
+  let newTemplate =
+    Input.OptionMaybe(
+      [ "--add"; "-a" ],
+      "Adds the template repository to Perla"
+    )
 
-  let SearchPackages =
-    let package =
-      Input.OptionRequired(
-        "package",
-        "The package you want to search for in the Skypack api"
-      )
+  let update =
+    Input.OptionMaybe(
+      [ "--update"; "-u" ],
+      "If it exists, updates the template repository for Perla"
+    )
 
-    let page =
-      Input.OptionMaybe(
-        [| "--page"; "-p" |],
-        "change the page number in the search results"
-      )
+  let remove =
+    Input.OptionMaybe(
+      [ "--remove"; "-r" ],
+      "If it exists, removes the template repository for Perla"
+    )
 
-    let buildArgs (package: string, page: int option) : SearchOptions =
-      { package = package
-        page = page |> Option.defaultValue 1 }
+  let display =
+    Input.OptionWithStrings(
+      [ "--list"; "-ls" ],
+      [ "table"; "simple" ],
+      defaultValue = "table",
+      description = "The chosen format to display the existing templates"
+    )
 
-    command "search" {
-      description
-        "Search a package name in the Skypack api, this will bring potential results"
+  let buildArgs
+    (
+      ctx: InvocationContext,
+      name: string,
+      add: bool option,
+      update: bool option,
+      remove: bool option,
+      format: string option
+    ) : TemplateRepositoryOptions * CancellationToken =
+    let operation =
+      let remove =
+        remove
+        |> Option.map (function
+          | true -> Some RunTemplateOperation.Remove
+          | false -> None)
+        |> Option.flatten
 
-      inputs (package, page)
-      setHandler (buildArgs >> Handlers.runSearch)
-    }
+      let update =
+        update
+        |> Option.map (function
+          | true -> Some RunTemplateOperation.Update
+          | false -> None)
+        |> Option.flatten
 
-  let ShowPackage =
-    let package =
-      Input.Argument(
-        "package",
-        "The package you want to search for in the Skypack api"
-      )
+      let add =
+        add
+        |> Option.map (function
+          | true -> Some RunTemplateOperation.Add
+          | false -> None)
+        |> Option.flatten
 
-    let buildArgs (package: string) : ShowPackageOptions = { package = package }
-
-    command "show" {
-      description
-        "Shows information about a package if the name matches an existing one"
-
-      inputs package
-      setHandler (buildArgs >> Handlers.runShow)
-    }
-
-  let RemovePackage =
-    let package =
-      Input.Argument(
-        "package",
-        "The package you want to search for in the Skypack api"
-      )
-
-    let alias =
-      Input.OptionMaybe(
-        [ "--alias"; "-a" ],
-        "the alias of the package if you added one"
-      )
-
-    let buildArgs
-      (
-        package: string,
-        alias: string option
-      ) : RemovePackageOptions =
-      { package = package; alias = alias }
-
-    command "remove" {
-      description "removes a package from the "
-
-      inputs (package, alias)
-      setHandler (buildArgs >> Handlers.runRemove)
-    }
-
-  let AddPackage =
-    let package =
-      Input.Argument(
-        "package",
-        "The package you want to search for in the skypack api"
-      )
-
-    let version =
-      let opt =
-        Aliases.Opt<string option>(
-          [| "-v"; "--version" |],
-          parseArgument =
-            (fun arg ->
-              arg.Tokens
-              |> Seq.tryHead
-              |> Option.map (fun token -> token.Value |> Option.ofObj)
-              |> Option.flatten)
+      let format =
+        format
+        |> Option.map (function
+          | "table" -> RunTemplateOperation.List ListFormat.HumanReadable
+          | _ -> RunTemplateOperation.List ListFormat.TextOnly)
+        |> Option.defaultValue (
+          RunTemplateOperation.List ListFormat.HumanReadable
         )
 
-      opt |> HandlerInput.OfOption
+      remove
+      |> Option.orElse update
+      |> Option.orElse add
+      |> Option.defaultValue format
 
-    let source =
-      Input.OptionWithStrings(
-        [ "--source"; "-s" ],
-        [ "jspm"; "skypack"; "unpkg"; "jsdelivr"; "jspm.system" ],
-        "jspm",
-        "CDN that will be used to fetch dependencies from"
-      )
+    { fullRepositoryName = name
+      operation = operation },
+    ctx.GetCancellationToken()
 
-    let dev =
-      Input.OptionMaybe(
-        [ "--dev"; "--development"; "-d" ],
-        "Adds this dependency to the dev dependencies"
-      )
-
-    let alias =
-      Input.OptionMaybe(
-        [ "--alias"; "-a" ],
-        "the alias of the package if you added one"
-      )
-
-    let buildArgs
-      (
-        package: string,
-        version: string option,
-        source: string option,
-        dev: bool option,
-        alias: string option
-      ) : AddPackageOptions =
-      { package = package
-        version = version
-        source = source |> Option.map Provider.FromString
-        mode =
-          dev
-          |> Option.map (fun dev ->
-            if dev then
-              RunConfiguration.Development
-            else
-              RunConfiguration.Production)
-        alias = alias }
-
-    command "add" {
+  let template =
+    command "templates" {
+      addAlias "t"
       description
-        "Shows information about a package if the name matches an existing one"
+        "Handles Template Repository operations such as list, add, update, and remove templates"
 
-      inputs (package, version, source, dev, alias)
-      setHandler (buildArgs >> Handlers.runAdd)
+      inputs (Input.Context(), repoName, newTemplate, update, remove, display)
+      setHandler (buildArgs >> Handlers.runTemplate)
     }
 
-  let ListDependencies =
+  template
 
-    let asNpm =
-      Input.OptionMaybe(
-        [ "--npm"; "--as-package-json"; "-j" ],
-        "Show the packages simlar to npm's package.json"
-      )
+let NewProject =
+  let name = Input.Argument("name", "Name of the new project")
 
-    let buildArgs (asNpm: bool option) : ListPackagesOptions =
-      { format =
-          asNpm
-          |> Option.map (fun asNpm ->
-            if asNpm then
-              ListFormat.TextOnly
-            else
-              ListFormat.HumanReadable)
-          |> Option.defaultValue ListFormat.HumanReadable }
+  let templateName =
+    Input.Option(
+      [ "-tn"; "--template-name" ],
+      "repository/directory combination of the template name, or the full name in case of name conflicts username/repository/directory"
+    )
 
-    command "list" {
-      description
-        "Lists the current dependencies in a table or an npm style json string"
+  let byId =
+    Input.Option(
+      [ "-id"; "--group-id" ],
+      "fully.qualified.name of the template, e.g. perla.templates.vanilla.js"
+    )
 
-      inputs asNpm
-      setHandler (buildArgs >> Handlers.runList)
-    }
+  let byShortName =
+    Input.Option([ "-t"; "--template" ], "shortname of the template, e.g. ff")
 
-  let Restore =
-    let source =
-      Input.OptionWithStrings(
-        [ "--source"; "-s" ],
-        [ "jspm"; "skypack"; "unpkg"; "jsdelivr"; "jspm.system" ],
-        description = "CDN that will be used to fetch dependencies from"
-      )
+  let buildArgs
+    (
+      ctx: InvocationContext,
+      name: string,
+      template: string option,
+      byId: string option,
+      byShortName: string option
+    ) : ProjectOptions * CancellationToken =
+    { projectName = name
+      byTemplateName = template
+      byId = byId
+      byShortName = byShortName },
+    ctx.GetCancellationToken()
 
-    let mode =
-      Input.OptionWithStrings(
-        [ "--mode"; "-m" ],
-        [ "dev"; "development"; "prod"; "production" ],
-        description = "Restore Dependencies based on the mode to run"
-      )
+  command "new" {
+    addAliases ["n"; "create"; "generate"]
+    description
+      "Creates a new project based on the selected template if it exists"
 
-    let buildArgs
-      (
-        source: string option,
-        mode: string option
-      ) : RestoreOptions =
-      { source = source |> Option.map Provider.FromString
-        mode = mode |> Option.map RunConfiguration.FromString }
+    inputs (Input.Context(), name, templateName, byId, byShortName)
+    setHandler (buildArgs >> Handlers.runNew)
+  }
 
-    command "restore" {
-      description
-        "Restore the import map based on the selected mode, defaults to production"
+let Test =
 
-      inputs (source, mode)
-      setHandler (buildArgs >> Handlers.runRestore)
-    }
+  let browsers =
+    Input.MultipleStrings(
+      "--browser",
+      [ "chromium"; "firefox"; "webkit"; "edge"; "chrome" ],
+      "Which browsers to run the tests on, defaults to 'chromium'"
+    )
 
-  let AddTemplate, UpdateTemplate =
-    let repoName =
-      Input.Argument(
-        "templateRepositoryName",
-        "The User/repository name combination"
-      )
+  let files: HandlerInput<string[]> =
+    Input.Option<string[]>(
+      [ "--tests"; "-t" ],
+      [||],
+      "Specify a glob of tests to run. e.g '**/featureA/*.test.js' or 'tests/my-test.test.js'"
+    )
 
-    let branch =
-      Input.ArgumentMaybe("banch", "Whch branch to pick the template from")
-
-    let yes = Input.OptionMaybe([ "--yes"; "--continue"; "-y" ], "skip prompts")
-
-    let buildArgs
-      (
-        name: string,
-        branch: string option,
-        yes: bool option
-      ) : TemplateRepositoryOptions =
-      { fullRepositoryName = name
-        branch = branch |> Option.defaultValue "main"
-        yes = yes |> Option.defaultValue false }
-
-    let add =
-      command "templates:add" {
-        description "Adds a new template from a particular repository"
-        inputs (repoName, branch, yes)
-        setHandler (buildArgs >> Handlers.runAddTemplate)
-      }
-
-    let update =
-      command "templates:update" {
-        description "Updates an existing template in the templates database"
-        inputs (repoName, branch, yes)
-        setHandler (buildArgs >> Handlers.runUpdateTemplate)
-      }
-
-    add, update
-
-  let ListTemplates =
-    let display =
-      Input.ArgumentWithStrings(
-        "format",
-        [ "table"; "simple" ],
-        description =
-          "The chosen format to display the existing perla templates"
-      )
-
-    let buildArgs (format: string option) : ListTemplatesOptions =
-      let toFormat (format: string) =
-        match format.ToLowerInvariant() with
-        | "table" -> ListFormat.HumanReadable
-        | _ -> ListFormat.TextOnly
-
-      { format =
-          format
-          |> Option.map toFormat
-          |> Option.defaultValue ListFormat.HumanReadable }
-
-    command "templates:list" {
-      inputs display
-      setHandler (buildArgs >> Handlers.runListTemplates)
-    }
-
-  let RemoveTemplate =
-    let repoName =
-      Input.Argument(
-        "templateRepositoryName",
-        "The User/repository name combination"
-      )
-
-    command "templates:delete" {
-      description "Removes a template from the templates database"
-      inputs repoName
-      setHandler Handlers.runRemoveTemplate
-    }
-
-  let NewProject =
-    let name = Input.Argument("name", "Name of the new project")
-
-    let templateName =
-      Input.Option(
-        [ "-tn"; "--template-name" ],
-        "repository/directory combination of the template name, or the full name in case of name conflicts username/repository/directory"
-      )
-
-    let byId =
-      Input.Option(
-        [ "-id"; "--group-id" ],
-        "fully.qualified.name of the template, e.g. perla.templates.vanilla.js"
-      )
-
-    let byShortName =
-      Input.Option([ "-t"; "--template" ], "shortname of the template, e.g. ff")
-
-    let buildArgs
-      (
-        ctx: InvocationContext,
-        name: string,
-        template: string option,
-        byId: string option,
-        byShortName: string option
-      ) : ProjectOptions * CancellationToken =
-      { projectName = name
-        byTemplateName = template
-        byId = byId
-        byShortName = byShortName },
-      ctx.GetCancellationToken()
-
-    command "new" {
-      description
-        "Creates a new project based on the selected template if it exists"
-
-      inputs (Input.Context(), name, templateName, byId, byShortName)
-      setHandler (buildArgs >> Handlers.runNew)
-    }
-
-  let Test =
-
-    let browsers =
-      Input.MultipleStrings(
-        "--browser",
-        [ "chromium"; "firefox"; "webkit"; "edge"; "chrome" ],
-        "Which browsers to run the tests on, defaults to 'chromium'"
-      )
-
-    let files: HandlerInput<string[]> =
-      Input.Option<string[]>(
-        [ "--tests"; "-t" ],
-        [||],
-        "Specify a glob of tests to run. e.g '**/featureA/*.test.js' or 'tests/my-test.test.js'"
-      )
-
-    let skips: HandlerInput<string[]> =
-      Input.Option<string[]>(
-        [ "--skip"; "-s" ],
-        [||],
-        "Specify a glob of tests to skip. e.g '**/featureA/*.test.js' or 'tests/my-test.test.js'"
-      )
+  let skips: HandlerInput<string[]> =
+    Input.Option<string[]>(
+      [ "--skip"; "-s" ],
+      [||],
+      "Specify a glob of tests to skip. e.g '**/featureA/*.test.js' or 'tests/my-test.test.js'"
+    )
 
 
-    let headless: HandlerInput<bool option> =
-      Input.OptionMaybe<bool>(
-        [ "--headless"; "-hl" ],
-        "Turn on or off the Headless mode and open the browser (useful for debugging tests)"
-      )
+  let headless: HandlerInput<bool option> =
+    Input.OptionMaybe<bool>(
+      [ "--headless"; "-hl" ],
+      "Turn on or off the Headless mode and open the browser (useful for debugging tests)"
+    )
 
-    let watch: HandlerInput<bool option> =
-      Input.OptionMaybe<bool>(
-        [ "--watch"; "-w" ],
-        "Start the server and keep watching for file changes"
-      )
+  let watch: HandlerInput<bool option> =
+    Input.OptionMaybe<bool>(
+      [ "--watch"; "-w" ],
+      "Start the server and keep watching for file changes"
+    )
 
-    let sequential: HandlerInput<bool option> =
-      Input.OptionMaybe<bool>(
-        [ "--browser-sequential"; "-bs" ],
-        "Run each browser's test suite in sequence, rather than parallel"
-      )
+  let sequential: HandlerInput<bool option> =
+    Input.OptionMaybe<bool>(
+      [ "--browser-sequential"; "-bs" ],
+      "Run each browser's test suite in sequence, rather than parallel"
+    )
 
-    let buildArgs
-      (
-        ctx: InvocationContext,
-        browsers: string array option,
-        files: string array,
-        skips: string array,
-        headless: bool option,
-        watch: bool option,
-        sequential: bool option
-      ) : CancellationToken * TestingOptions =
-      ctx.GetCancellationToken(),
-      { browsers =
-          browsers
-          |> Option.map (fun browsers ->
-            if browsers |> Array.isEmpty then
-              None
-            else
-              Some(browsers |> Seq.map Browser.FromString))
-          |> Option.flatten
-        files = if files |> Array.isEmpty then None else Some files
-        skip = if skips |> Array.isEmpty then None else Some skips
-        headless = headless
-        watch = watch
-        browserMode =
-          sequential
-          |> Option.map (fun sequential ->
-            if sequential then Some BrowserMode.Sequential else None)
-          |> Option.flatten }
-
-    command "test" {
-      description "Runs client side tests in a headless browser"
-
-      inputs (
-        Input.Context(),
-        browsers,
-        files,
-        skips,
-        headless,
-        watch,
+  let buildArgs
+    (
+      ctx: InvocationContext,
+      browsers: string array option,
+      files: string array,
+      skips: string array,
+      headless: bool option,
+      watch: bool option,
+      sequential: bool option
+    ) : TestingOptions * CancellationToken =
+    { browsers =
+        browsers
+        |> Option.map (fun browsers ->
+          if browsers |> Array.isEmpty then
+            None
+          else
+            Some(browsers |> Seq.map Browser.FromString))
+        |> Option.flatten
+      files = if files |> Array.isEmpty then None else Some files
+      skip = if skips |> Array.isEmpty then None else Some skips
+      headless = headless
+      watch = watch
+      browserMode =
         sequential
-      )
+        |> Option.map (fun sequential ->
+          if sequential then Some BrowserMode.Sequential else None)
+        |> Option.flatten },
+    ctx.GetCancellationToken()
 
-      setHandler (buildArgs >> Handlers.runTesting)
-    }
+  command "test" {
+    description "Runs client side tests in a headless browser"
 
-  let Describe =
-    let perlaProperties: HandlerInput<string[] option> =
-      Arg<string[] option>(
-        "properties",
-        (fun (result: ArgumentResult) ->
-          match result.Tokens |> Seq.toArray with
-          | [||] -> None
-          | others -> Some(others |> Array.map (fun token -> token.Value))),
-        Description =
-          "A property, properties or json path-like string names to describe",
-        Arity = ArgumentArity.ZeroOrMore
-      )
-      |> HandlerInput.OfArgument
+    inputs (
+      Input.Context(),
+      browsers,
+      files,
+      skips,
+      headless,
+      watch,
+      sequential
+    )
 
-    let describeCurrent: HandlerInput<bool> =
-      Input.Option(
-        [ "--current"; "-c" ],
-        false,
-        "Take my current perla.json file and print my current configuration"
-      )
+    setHandler (buildArgs >> Handlers.runTesting)
+  }
 
-    let buildArgs
-      (
-        ctx: InvocationContext,
-        properties: string[] option,
-        current: bool
-      ) =
-      ctx.GetCancellationToken(),
-      { properties = properties
-        current = current }
+let Describe =
+  let perlaProperties: HandlerInput<string[] option> =
+    Arg<string[] option>(
+      "properties",
+      (fun (result: ArgumentResult) ->
+        match result.Tokens |> Seq.toArray with
+        | [||] -> None
+        | others -> Some(others |> Array.map (fun token -> token.Value))),
+      Description =
+        "A property, properties or json path-like string names to describe",
+      Arity = ArgumentArity.ZeroOrMore
+    )
+    |> HandlerInput.OfArgument
 
-    command "describe" {
-      description
-        "Describes the perla.json file or it's properties as requested"
+  let describeCurrent: HandlerInput<bool> =
+    Input.Option(
+      [ "--current"; "-c" ],
+      false,
+      "Take my current perla.json file and print my current configuration"
+    )
 
-      inputs (Input.Context(), perlaProperties, describeCurrent)
-      setHandler (buildArgs >> Handlers.runDescribe)
-    }
+  let buildArgs (properties: string[] option, current: bool) =
+    { properties = properties
+      current = current }
+
+  command "describe" {
+    addAlias "ds"
+    description "Describes the perla.json file or it's properties as requested"
+
+    inputs (perlaProperties, describeCurrent)
+    setHandler (buildArgs >> Handlers.runDescribePerla)
+  }

--- a/src/Perla/Commands.fsi
+++ b/src/Perla/Commands.fsi
@@ -1,0 +1,21 @@
+﻿[<RequireQualifiedAccess>]
+module Perla.Commands
+
+open System.CommandLine
+
+val Setup: Command
+val Template: Command
+val Describe: Command
+
+val Build: Command
+val Serve: Command
+val Test: Command
+
+val SearchPackage: Command
+val ShowPackage: Command
+val AddPackage: Command
+val RemovePackage: Command
+val ListPackages: Command
+val RestoreImportMap: Command
+
+val NewProject: Command

--- a/src/Perla/Commands.fsi
+++ b/src/Perla/Commands.fsi
@@ -1,21 +1,99 @@
-﻿[<RequireQualifiedAccess>]
-module Perla.Commands
+﻿namespace Perla.Commands
 
 open System.CommandLine
+open FSharp.SystemCommandLine
 
-val Setup: Command
-val Template: Command
-val Describe: Command
+open Perla.Handlers
+open Perla.Types
+open Perla.PackageManager.Types
 
-val Build: Command
-val Serve: Command
-val Test: Command
 
-val SearchPackage: Command
-val ShowPackage: Command
-val AddPackage: Command
-val RemovePackage: Command
-val ListPackages: Command
-val RestoreImportMap: Command
+[<Class; Sealed>]
+type PerlaOptions =
+    static member PackageSource: Option<Provider voption>
+    static member RunConfiguration: Option<RunConfiguration voption>
+    static member Browsers: Option<Browser list>
+    static member DisplayMode: Option<ListFormat>
 
-val NewProject: Command
+[<Class; Sealed>]
+type PerlaArguments =
+    static member Properties: Argument<string list>
+
+[<RequireQualifiedAccess>]
+module SharedInputs =
+    val asDev: HandlerInput<bool option>
+    val source: HandlerInput<Provider voption>
+    val mode: HandlerInput<RunConfiguration voption>
+
+[<RequireQualifiedAccess>]
+module DescribeInputs =
+    val perlaProperties: HandlerInput<string array option>
+    val describeCurrent: HandlerInput<bool>
+
+[<RequireQualifiedAccess>]
+module BuildInputs =
+    val enablePreloads: HandlerInput<bool option>
+    val rebuildImportMap: HandlerInput<bool option>
+    val preview: HandlerInput<bool option>
+
+[<RequireQualifiedAccess>]
+module SetupInputs =
+    val skipPrompts: HandlerInput<bool option>
+    val skipPlaywright: HandlerInput<bool option>
+
+[<RequireQualifiedAccess>]
+module PackageInputs =
+    val package : HandlerInput<string>
+    val alias: HandlerInput<string option>
+    val version: HandlerInput<string option>
+    val currentPage: HandlerInput<int option>
+    val showAsNpm: HandlerInput<bool option>
+
+[<RequireQualifiedAccess>]
+module TemplateInputs =
+    val repositoryName: HandlerInput<string>
+    val addTemplate: HandlerInput<bool option>
+    val updateTemplate: HandlerInput<bool option>
+    val removeTemplate: HandlerInput<bool option>
+    val displayMode: HandlerInput<ListFormat>
+
+[<RequireQualifiedAccess>]
+module ProjectInputs =
+    val projectName: HandlerInput<string>
+    val templateName: HandlerInput<string option>
+    val byId: HandlerInput<string option>
+    val byShortName: HandlerInput<string option>
+
+[<RequireQualifiedAccess>]
+module TestingInputs =
+    val browsers: HandlerInput<Browser list>
+    val files: HandlerInput<string array>
+    val skips: HandlerInput<string array>
+    val headless: HandlerInput<bool option>
+    val watch: HandlerInput<bool option>
+    val sequential: HandlerInput<bool option>
+
+[<RequireQualifiedAccess>]
+module ServeInputs =
+    val port: HandlerInput<int option>
+    val host: HandlerInput<string option>
+    val ssl: HandlerInput<bool option>
+
+[<RequireQualifiedAccess>]
+module Commands =
+    val Setup: Command
+    val Template: Command
+    val Describe: Command
+
+    val Build: Command
+    val Serve: Command
+    val Test: Command
+
+    val SearchPackage: Command
+    val ShowPackage: Command
+    val AddPackage: Command
+    val RemovePackage: Command
+    val ListPackages: Command
+    val RestoreImportMap: Command
+
+    val NewProject: Command

--- a/src/Perla/FileSystem.fs
+++ b/src/Perla/FileSystem.fs
@@ -31,6 +31,7 @@ open Perla.Units
 open Perla.Json
 open Perla.Logger
 open Perla.PackageManager.Types
+open Perla.Types
 
 [<RequireQualifiedAccess>]
 type PerlaFileChange =
@@ -438,22 +439,6 @@ type FileSystem =
         PerlaFileChange.ImportMap
       | _ -> PerlaFileChange.Index)
 
-
-  static member PathForTemplate
-    (
-      username: string,
-      repository: string,
-      branch: string,
-      ?tplName: string
-    ) =
-    let tplName = defaultArg tplName ""
-
-    Path.Combine(
-      UMX.untag FileSystem.Templates,
-      $"{username}-{repository}-{branch}",
-      tplName
-    )
-
   static member SetupEsbuild
     (
       esbuildVersion: string<Semver>,
@@ -489,43 +474,6 @@ type FileSystem =
             path)
       )
 
-  static member GetTemplateScriptContent
-    (
-      username: string,
-      repository: string,
-      branch: string,
-      ?tplName: string
-    ) =
-    let readTemplateScript =
-      let templateScriptPath =
-        FileSystem.PathForTemplate(
-          username,
-          repository,
-          branch,
-          ?tplName = tplName
-        )
-
-      try
-        File.ReadAllText(
-          Path.Combine(templateScriptPath, Constants.TemplatingScriptName)
-        )
-        |> Some
-      with _ ->
-        None
-
-    let readRepoScript () =
-      let repositoryScriptPath =
-        FileSystem.PathForTemplate(username, repository, branch)
-
-      try
-        File.ReadAllText(
-          Path.Combine(repositoryScriptPath, Constants.TemplatingScriptName)
-        )
-        |> Some
-      with _ ->
-        None
-
-    readTemplateScript |> Option.orElseWith (fun () -> readRepoScript ())
 
   static member WriteTplRepositoryToDisk
     (

--- a/src/Perla/FileSystem.fsi
+++ b/src/Perla/FileSystem.fsi
@@ -10,7 +10,7 @@ open FSharp.UMX
 open Perla.Types
 open Perla.Units
 open Perla.PackageManager.Types
-
+open Perla.Json
 
 [<RequireQualifiedAccess>]
 type PerlaFileChange =
@@ -38,7 +38,9 @@ module FileSystem =
     val GetConfigPath: fileName: string -> fromDirectory: string<SystemPath> option -> string<SystemPath>
 
     val ExtractTemplateZip:
-        username: string * repository: string * branch: string -> stream: Stream -> string<SystemPath>
+        username: string * repository: string * branch: string ->
+            stream: Stream ->
+                string<SystemPath> * Result<TemplateDecoders.DecodedTemplateConfiguration, string>
 
     val RemoveTemplateDirectory: path: string<SystemPath> -> unit
     val EsbuildBinaryPath: string<Semver> option -> string<SystemPath>
@@ -51,16 +53,22 @@ type FileSystem =
     static member PerlaConfigText: ?fromDirectory: string<SystemPath> -> string option
     static member SetCwdToPerlaRoot: ?fromPath: string<SystemPath> -> unit
     static member GetImportMap: ?fromDirectory: string<SystemPath> -> ImportMap
+
     static member SetupEsbuild:
         esbuildVersion: string<Semver> * [<Optional>] ?cancellationToken: CancellationToken -> Task<unit>
+
     static member WriteImportMap: map: ImportMap * ?fromDirectory: string<SystemPath> -> ImportMap
     static member WritePerlaConfig: ?config: JsonObject * ?fromDirectory: string<SystemPath> -> unit
     static member PathForTemplate: username: string * repository: string * branch: string * ?tplName: string -> string
+
     static member WriteTplRepositoryToDisk:
         origin: string<SystemPath> * target: string<UserPath> * ?payload: obj -> unit
+
     static member GetTemplateScriptContent:
         username: string * repository: string * branch: string * ?tplName: string -> string option
+
     static member IndexFile: fromConfig: string<SystemPath> -> string
     static member PluginFiles: unit -> (string * string) array
+
     static member ObservePerlaFiles:
         indexPath: string * [<Optional>] ?cancellationToken: CancellationToken -> IObservable<PerlaFileChange>

--- a/src/Perla/FileSystem.fsi
+++ b/src/Perla/FileSystem.fsi
@@ -18,7 +18,6 @@ type PerlaFileChange =
     | PerlaConfig
     | ImportMap
 
-
 [<RequireQualifiedAccess>]
 module FileSystem =
     module Operators =
@@ -59,13 +58,9 @@ type FileSystem =
 
     static member WriteImportMap: map: ImportMap * ?fromDirectory: string<SystemPath> -> ImportMap
     static member WritePerlaConfig: ?config: JsonObject * ?fromDirectory: string<SystemPath> -> unit
-    static member PathForTemplate: username: string * repository: string * branch: string * ?tplName: string -> string
 
     static member WriteTplRepositoryToDisk:
         origin: string<SystemPath> * target: string<UserPath> * ?payload: obj -> unit
-
-    static member GetTemplateScriptContent:
-        username: string * repository: string * branch: string * ?tplName: string -> string option
 
     static member IndexFile: fromConfig: string<SystemPath> -> string
     static member PluginFiles: unit -> (string * string) array

--- a/src/Perla/Handlers.fs
+++ b/src/Perla/Handlers.fs
@@ -1,0 +1,1565 @@
+﻿namespace Perla.Handlers
+
+open System
+open System.IO
+
+open System.Threading
+open System.Threading.Tasks
+
+open AngleSharp.Html.Parser
+open Microsoft.Playwright
+open Spectre.Console
+
+open FSharp.Control
+open FSharp.Control.Reactive
+
+open FSharp.UMX
+open FsToolkit.ErrorHandling
+
+open AngleSharp
+open Zio.FileSystems
+open Zio
+
+open Perla
+open Perla.Types
+open Perla.Units
+open Perla.Server
+open Perla.Build
+open Perla.Logger
+open Perla.FileSystem
+open Perla.VirtualFs
+open Perla.Esbuild
+open Perla.Fable
+open Perla.Json
+open Perla.Scaffolding
+open Perla.Configuration.Types
+open Perla.Configuration
+open Perla.Extensibility
+
+open Perla.Plugins
+open Perla.PackageManager
+open Perla.PackageManager.Types
+
+open Perla.Testing
+
+[<Struct; RequireQualifiedAccess>]
+type ListFormat =
+  | HumanReadable
+  | TextOnly
+
+type ServeOptions =
+  { port: int option
+    host: string option
+    mode: RunConfiguration option
+    ssl: bool option }
+
+type BuildOptions =
+  { mode: RunConfiguration option
+    enablePreview: bool
+    enablePreloads: bool
+    rebuildImportMap: bool }
+
+type SetupOptions =
+  { skipPrompts: bool
+    skipPlaywright: bool }
+
+type SearchOptions = { package: string; page: int }
+
+type ShowPackageOptions = { package: string }
+
+type ListTemplatesOptions = { format: ListFormat }
+
+type AddPackageOptions =
+  { package: string
+    version: string option
+    source: Provider option
+    mode: RunConfiguration option
+    alias: string option }
+
+type RemovePackageOptions =
+  { package: string
+    alias: string option }
+
+type ListPackagesOptions = { format: ListFormat }
+
+[<RequireQualifiedAccess; Struct>]
+type RunTemplateOperation =
+  | Add
+  | Update
+  | Remove
+  | List of ListFormat
+
+type TemplateRepositoryOptions =
+  { fullRepositoryName: string
+    operation: RunTemplateOperation }
+
+type ProjectOptions =
+  { projectName: string
+    byTemplateName: string option
+    byId: string option
+    byShortName: string option }
+
+type RestoreOptions =
+  { source: Provider option
+    mode: RunConfiguration option }
+
+type TestingOptions =
+  { browsers: Browser seq option
+    files: string seq option
+    skip: string seq option
+    watch: bool option
+    headless: bool option
+    browserMode: BrowserMode option }
+
+type DescribeOptions =
+  { properties: string[] option
+    current: bool }
+
+module Templates =
+
+  type FoundTemplate =
+    | Repository of PerlaTemplateRepository
+    | Existing of TemplateItem
+
+  type TemplateNotFoundCases =
+    | NoQueryParams
+    | ParentTemplateNotFound
+    | ChildTemplateNotFound
+
+  [<RequireQualifiedAccess; Struct>]
+  type TemplateOperation =
+    | Add of repoName: (string * string * string)
+    | Update of foundRepo: PerlaTemplateRepository
+
+  let private updateTemplate
+    (template: PerlaTemplateRepository)
+    (branch: string)
+    (context: StatusContext)
+    =
+    context.Status <-
+      $"Download and extracting template {template.ToFullNameWithBranch}"
+
+    Templates.Update({ template with branch = branch })
+
+  let private addTemplate
+    (user: string)
+    (repository: string)
+    (branch: string)
+    (context: StatusContext)
+    =
+    context.Status <-
+      $"Download and extracting template {user}/{repository}:{branch}"
+
+    Templates.Add(user, repository, branch)
+
+
+  let List (options: ListTemplatesOptions) =
+    let results =
+      Templates.ListTemplateItems()
+      |> List.groupBy (fun x -> x.parent)
+      |> List.choose (fun (parentId, children) ->
+        match Templates.FindOne(TemplateSearchKind.Id parentId) with
+        | Some parent -> Some(parent, children)
+        | None -> None)
+      |> List.collect (fun (parent, children) ->
+        children |> List.map (fun child -> (parent, child)))
+
+    match options.format with
+    | ListFormat.HumanReadable ->
+      let table =
+        Table()
+          .AddColumns(
+            [| "Name"
+               "Group"
+               "Belongs to"
+               "Parent Location"
+               "Last Update" |]
+          )
+
+      for column in table.Columns do
+        column.Alignment <- Justify.Center
+
+      for parent, template in results do
+        let name: Rendering.IRenderable =
+          Markup($"[bold green]{template.name}[/]")
+
+        let group = Markup($"[bold yellow]{template.group}[/]")
+        let belongsTo = Markup($"[bold blue]{parent.ToFullNameWithBranch}[/]")
+
+        let lastUpdate =
+          parent.updatedAt
+          |> Option.ofNullable
+          |> Option.defaultValue parent.createdAt
+          |> (fun x -> $"[bold green]{x.ToShortDateString()}[/]")
+          |> Markup
+
+        let location =
+          TextPath(
+            UMX.untag parent.path,
+            LeafStyle = Style(Color.Green),
+            StemStyle = Style(Color.Yellow),
+            SeparatorStyle = Style(Color.Blue)
+          )
+
+        table.AddRow([| name; group; belongsTo; location; lastUpdate |])
+        |> ignore
+
+      AnsiConsole.Write table
+      0
+    | ListFormat.TextOnly ->
+      let columns =
+        Columns([| "Name"; "Group"; "Belongs to"; "Parent Location" |])
+
+      AnsiConsole.Write columns
+
+      let rows =
+        [| for parent, template in results do
+             let name = Markup($"[bold green]{template.name}[/]")
+             let group = Markup($"[bold yellow]{template.group}[/]")
+
+             let belongsTo =
+               Markup($"[bold blue]{parent.ToFullNameWithBranch}[/]")
+
+             let location =
+               TextPath(
+                 UMX.untag parent.path,
+                 LeafStyle = Style(Color.Green),
+                 StemStyle = Style(Color.Yellow),
+                 SeparatorStyle = Style(Color.Blue)
+               )
+
+             Columns(name, group, belongsTo, location) :> Rendering.IRenderable |]
+
+      rows |> Rows |> AnsiConsole.Write
+
+      0
+
+  let AddOrUpdate (operation: TemplateOperation) =
+    taskResult {
+      let listTemplates () =
+        List { format = ListFormat.HumanReadable } |> ignore
+
+        Logger.log (
+          "[bold yellow]perla[/] [bold blue]new [/] [bold blue] <PROJECT_NAME>[/]",
+          escape = false
+        )
+
+        Logger.log "Feel free to create a new perla project"
+
+      match operation with
+      | TemplateOperation.Add repoName ->
+        let username, repository, branch = repoName
+
+        do!
+          Logger.spinner (
+            $"Adding templates from: {username}/{repository}:{branch}",
+            (addTemplate username repository branch)
+          )
+          |> TaskResult.ignore
+
+        listTemplates ()
+        return ()
+      | TemplateOperation.Update template ->
+        do!
+          taskResult {
+            let! result =
+              Logger.spinner (
+                $"Updating templates from: {template.ToFullNameWithBranch}",
+                (updateTemplate template template.branch)
+              )
+
+            if result then
+              return ()
+            else
+              return!
+                Error
+                  "We were unable to update the existing [bold red]templates[/]."
+          }
+
+        listTemplates ()
+        return ()
+    }
+
+  let Remove (template: PerlaTemplateRepository) : Result<unit, string> =
+    Templates.Delete(TemplateSearchKind.Id template._id)
+    |> Result.requireTrue
+      "There was an error while trying to delete this template."
+
+module Fable =
+  let StartFable (config: PerlaConfig, cancel: CancellationToken) =
+    task {
+      match config.fable with
+      | Some fable -> do! Fable.Start(fable, cancellationToken = cancel) :> Task
+      | None ->
+        Logger.log (
+          "No Fable configuration provided, skipping fable",
+          target = PrefixKind.Build
+        )
+    }
+
+module FsMonitor =
+  let FirstCompileDone isWatch (observable: IObservable<FableEvent>) =
+    observable
+    |> Observable.choose (function
+      | FableEvent.WaitingForChanges -> Some()
+      | _ -> None)
+    |> (fun obs ->
+      if isWatch then
+        Observable.first obs
+      else
+        Observable.takeLast 1 obs)
+    |> AsyncSeq.ofObservableBuffered
+    |> AsyncSeq.iter ignore
+
+  let FileChanges
+    (
+      index: string,
+      mountDirectories,
+      perlaFilesChanges,
+      plugins: string list
+    ) =
+    let perlaFilesChanges =
+      perlaFilesChanges
+      |> Observable.map (fun event ->
+        let name, path, extension =
+          match event with
+          | PerlaFileChange.Index ->
+            (Path.GetFileName index, Path.GetFullPath index, ".html")
+          | PerlaFileChange.PerlaConfig ->
+            (Constants.PerlaConfigName,
+             UMX.untag FileSystem.PerlaConfigPath,
+             ".json")
+          | PerlaFileChange.ImportMap ->
+            (Constants.ImportMapName,
+             UMX.untag (FileSystem.GetConfigPath Constants.ImportMapName None),
+             ".importmap")
+
+        { serverPath = UMX.tag "/"
+          userPath = UMX.tag "/"
+          oldPath = None
+          oldName = None
+          changeType = ChangeKind.Changed
+          path = UMX.tag path
+          name = UMX.tag name },
+        { content = ""; extension = extension })
+
+    VirtualFileSystem.GetFileChangeStream mountDirectories
+    |> VirtualFileSystem.ApplyVirtualOperations plugins
+    |> Observable.merge perlaFilesChanges
+
+module Esbuild =
+
+  let Run
+    (
+      config: PerlaConfig,
+      workingDirectory: UPath,
+      fs: IFileSystem,
+      (css, js): string<ServerUrl> seq * string<ServerUrl> seq,
+      externals: string seq,
+      cancel: CancellationToken
+    ) =
+    let cssTasks =
+      backgroundTask {
+        for css in css do
+          let path =
+            UPath.Combine(workingDirectory, UMX.untag css)
+            |> fs.ConvertPathToInternal
+
+          let targetPath =
+            Path.Combine(UMX.untag config.build.outDir, UMX.untag css)
+            |> Path.GetDirectoryName
+            |> UMX.tag<SystemPath>
+
+          let tsk =
+            Esbuild
+              .ProcessCss(path, config.esbuild, targetPath)
+              .ExecuteAsync(cancel)
+
+          do! tsk.Task :> Task
+      }
+
+    let jsTasks =
+      backgroundTask {
+        for js in js do
+          let path =
+            UPath.Combine(workingDirectory, UMX.untag js)
+            |> fs.ConvertPathToInternal
+
+          let targetPath =
+            Path.Combine(UMX.untag config.build.outDir, UMX.untag js)
+            |> Path.GetDirectoryName
+            |> UMX.tag<SystemPath>
+
+          let tsk =
+            Esbuild
+              .ProcessJS(path, config.esbuild, targetPath, externals)
+              .ExecuteAsync(cancel)
+
+          do! tsk.Task :> Task
+      }
+
+    Task.WhenAll(cssTasks, jsTasks)
+
+module Setup =
+  /// set esbuild, playwright and import map dependencies in parallel
+  /// as these are not overlapping and should save time
+  let EnsureDependencies (config, cancel) =
+    task {
+      let! results =
+        [ task {
+            do Testing.SetupPlaywright()
+            return None
+          }
+          task {
+            do! FileSystem.SetupEsbuild(config.esbuild.version, cancel)
+            return None
+          }
+          task {
+            let! result =
+              Logger.spinner (
+                "Resolving Static dependencies and import map...",
+                Dependencies.GetMapAndDependencies(
+                  [ yield! config.dependencies; yield! config.devDependencies ]
+                  |> Seq.map (fun d -> d.AsVersionedString),
+                  config.provider
+                )
+              )
+
+            return
+              result
+              |> Result.defaultWith (fun _ ->
+                (Seq.empty, FileSystem.GetImportMap()))
+              |> Some
+          } ]
+        |> Task.WhenAll
+
+      return results[2].Value
+    }
+
+module Testing =
+  let RunOnce
+    (
+      pl: IPlaywright,
+      browserMode: BrowserMode,
+      browsers: Browser seq,
+      isHeadless: bool,
+      url: string
+    ) =
+    let browsers =
+      asyncSeq {
+        for browser in browsers do
+          let! iBrowser =
+            Testing.GetBrowser(pl, browser, isHeadless) |> Async.AwaitTask
+
+          browser, iBrowser
+      }
+
+    let runTest (browser, iBrowser) =
+      async {
+        let executor = Testing.GetExecutor(url, browser)
+        do! executor iBrowser |> Async.AwaitTask
+        do! iBrowser.CloseAsync() |> Async.AwaitTask
+        return! iBrowser.DisposeAsync().AsTask() |> Async.AwaitTask
+      }
+
+    match browserMode with
+    | BrowserMode.Parallel ->
+      browsers |> AsyncSeq.iterAsyncParallelThrottled 2 runTest
+    | BrowserMode.Sequential -> browsers |> AsyncSeq.iterAsync runTest
+
+  let LiveRun
+    (
+      pl: IPlaywright,
+      browser: Browser,
+      isHeadless: bool,
+      url: string,
+      fileChanges: IObservable<unit>,
+      broadcast: IObservable<TestEvent>,
+      cancel: CancellationToken
+    ) =
+    task {
+
+      let! iBrowser = Testing.GetBrowser(pl, browser, isHeadless)
+
+      let liveExecutor =
+        Testing.GetLiveExecutor(
+          url,
+          browser,
+          fileChanges |> Observable.map ignore
+        )
+
+      use _ = Testing.PrintReportLive broadcast
+      let! pageReloads = liveExecutor iBrowser
+
+      use _ =
+        pageReloads
+        |> Observable.subscribeSafe (fun _ ->
+          Logger.log $"Live Reload: Page Reloaded After Change")
+
+      while not cancel.IsCancellationRequested do
+        do! Async.Sleep(TimeSpan.FromSeconds(1.))
+    }
+
+[<RequireQualifiedAccess>]
+module Handlers =
+
+  let runSetup (options: SetupOptions, cancellationToken: CancellationToken) =
+    task {
+      Logger.log "Perla will set up the following resources:"
+      Logger.log "- Esbuild"
+      Logger.log "- Default Templates"
+
+      if not options.skipPlaywright then
+        Logger.log
+          "- Playwright browsers (required for the 'perla test' command)"
+      else
+        Logger.log "- Playwright browsers (skipped)"
+
+      Logger.log
+        "After that you should be able to run 'perla build' or 'perla new'"
+
+      do! FileSystem.SetupEsbuild(UMX.tag Constants.Esbuild_Version)
+      Logger.log ("[bold green]esbuild[/] has been setup!", escape = false)
+
+      match options.skipPrompts, options.skipPlaywright with
+      | true, true -> Logger.log "Skipping Playwright setup"
+      | true, false -> Testing.SetupPlaywright()
+      | false, true -> Logger.log "Skipping Playwright setup"
+      | false, false ->
+        if
+          AnsiConsole.Confirm(
+            "Install Playwright browsers? (required for 'perla test' command)",
+            false
+          )
+        then
+          Testing.SetupPlaywright()
+        else
+          Logger.log "Skipping Playwright setup"
+
+      let username, repository, branch =
+        PerlaTemplateRepository.DefaultTemplatesRepository
+
+      let getTemplate () =
+        TemplateSearchKind.FullName(username, repository)
+        |> Templates.FindOne
+        |> Option.map (fun template ->
+          Templates.AddOrUpdate(Templates.TemplateOperation.Update template))
+        |> Option.defaultWith (fun () ->
+          Templates.AddOrUpdate(
+            Templates.TemplateOperation.Add(username, repository, branch)
+          ))
+
+      if options.skipPrompts then
+        let! operation = getTemplate ()
+
+        match operation with
+        | Ok() -> return 0
+        | Error err ->
+          Logger.log (err, escape = false)
+          return 1
+      else if AnsiConsole.Confirm("Add default templates?", false) then
+        let! operation = getTemplate ()
+
+        match operation with
+        | Ok() -> return 0
+        | Error err ->
+          Logger.log (err, escape = false)
+          return 1
+      else
+        Logger.log "Skip installing templates"
+        return 0
+    }
+
+  let runNew
+    (
+      options: ProjectOptions,
+      cancellationToken: CancellationToken
+    ) : Task<int> =
+    Logger.log "Creating new project..."
+    let mutable mentionQuickCommand = false
+
+    let inline byId () =
+      options.byId
+      |> Option.map UMX.tag<TemplateGroup>
+      |> Option.map QuickAccessSearch.Group
+
+    let inline byTemplateName () =
+      options.byTemplateName |> Option.map QuickAccessSearch.Name
+
+    let queryParam =
+      options.byShortName
+      |> Option.map QuickAccessSearch.ShortName
+      |> Option.orElseWith byId
+      |> Option.orElseWith byTemplateName
+
+    let foundRepo =
+      result {
+        let! query = queryParam |> Result.requireSome Templates.NoQueryParams
+
+        match query with
+        | QuickAccessSearch.Name name ->
+          let user, template, child = getTemplateAndChild name
+
+          let! found =
+            (match user, child with
+             | Some user, _ ->
+               Templates.FindOne(TemplateSearchKind.FullName(user, template))
+             | None, _ ->
+               Templates.FindOne(TemplateSearchKind.Repository template))
+            |> Result.requireSome Templates.ParentTemplateNotFound
+
+          return Templates.Repository found
+        | others ->
+          let! found =
+            Templates.FindTemplateItems(others)
+            |> Result.requireHead Templates.ChildTemplateNotFound
+
+          return Templates.Existing found
+      }
+
+    let inline TemplateItemPromptConverter (item: TemplateItem) =
+      let description =
+        item.description |> Option.defaultValue "No description provided."
+
+      $"{item.name} - {item.shortName}: {description[0..30]}"
+
+    let inline TemplateConfigPromptConverter (item: TemplateConfigurationItem) =
+      $"{item.name} - {item.shortName}: {item.description[0..30]}"
+
+    let selectedItem =
+      match foundRepo with
+      | Ok(Templates.Repository repo) ->
+        mentionQuickCommand <- true
+
+        let selection =
+          SelectionPrompt(
+            Title = $"Available templates for {repo.name}",
+            Converter = TemplateConfigPromptConverter
+          )
+            .AddChoices(repo.templates)
+
+        task {
+          let! result =
+            selection.ShowAsync(AnsiConsole.Console, cancellationToken)
+
+          return
+            Templates.FindTemplateItems(QuickAccessSearch.Id result.childId)
+            |> List.tryHead
+        }
+      | Ok(Templates.Existing item) -> Task.FromResult(Some item)
+      | Error Templates.NoQueryParams ->
+        mentionQuickCommand <- true
+
+        let selection =
+          SelectionPrompt(
+            Title = "Welcome to Perla, please select a template to start with",
+            Converter = TemplateItemPromptConverter
+          )
+            .AddChoices(Templates.ListTemplateItems())
+
+        task {
+          try
+            let! result =
+              selection.ShowAsync(AnsiConsole.Console, cancellationToken)
+
+            return Some result
+          with :? TaskCanceledException ->
+            return None
+        }
+      | Error Templates.ChildTemplateNotFound
+      | Error Templates.ParentTemplateNotFound ->
+        if
+          AnsiConsole.Ask(
+            "We were not able to find the template you were looking for, Would you like to check the existing templates?",
+            false
+          )
+        then
+          mentionQuickCommand <- true
+
+          let selection =
+            SelectionPrompt(
+              Title = "Please select a template to start with",
+              Converter = TemplateItemPromptConverter
+            )
+              .AddChoices(Templates.ListTemplateItems())
+
+          task {
+            try
+              let! result =
+                selection.ShowAsync(AnsiConsole.Console, cancellationToken)
+
+              return Some result
+            with :? TaskCanceledException ->
+              return None
+          }
+        else
+          Task.FromResult None
+
+    task {
+      let! item = selectedItem
+
+      match item with
+      | Some item ->
+        let scriptContent =
+          Templates.GetTemplateScriptContent(TemplateScriptKind.Template item)
+          |> Option.orElseWith (fun () ->
+            option {
+              let! repo = Templates.FindOne(TemplateSearchKind.Id item.parent)
+
+              return!
+                TemplateScriptKind.Repository repo
+                |> Templates.GetTemplateScriptContent
+            })
+
+        let targetPath =
+          $"./{options.projectName}" |> Path.GetFullPath |> UMX.tag<UserPath>
+
+        FileSystem.WriteTplRepositoryToDisk(
+          item.fullPath,
+          targetPath,
+          ?payload = scriptContent
+        )
+
+
+        if mentionQuickCommand then
+          Logger.log "This template has quick access commands:"
+
+          Logger.log (
+            $"[bold yellow]perla new <my-project-name> -t {item.shortName}[/]",
+            escape = false
+          )
+
+          Logger.log (
+            $"Next time you can run [bold yellow]perla new <my-project-name> -id {item.group}[/]",
+            escape = false
+          )
+
+        Logger.log
+          $"Project [yellow]{options.projectName}[/] created successfully!"
+
+        return 0
+
+      | None ->
+        Logger.log "No selection was available..."
+
+        Logger.log
+          "please check for typos or run 'perla new <my-project-name>' to run the templating wizard"
+
+        return 0
+    }
+
+  let runTemplate
+    (
+      options: TemplateRepositoryOptions,
+      cancellationToken: CancellationToken
+    ) =
+    task {
+      let template =
+        voption {
+          let! username, repository, _ =
+            parseFullRepositoryName options.fullRepositoryName
+
+          return!
+            TemplateSearchKind.FullName(username, repository)
+            |> Templates.FindOne
+        }
+
+      let updateRepo () =
+        task {
+          let template = template.Value
+          Logger.log $"Template {template.ToFullNameWithBranch} already exists."
+
+          match!
+            Templates.AddOrUpdate(Templates.TemplateOperation.Update template)
+          with
+          | Ok() -> return 0
+          | Error err ->
+            Logger.log (err, escape = false)
+            return 1
+        }
+
+      match options.operation with
+      | RunTemplateOperation.List listFormat ->
+        return Templates.List { format = listFormat }
+      | RunTemplateOperation.Add ->
+        match parseFullRepositoryName options.fullRepositoryName with
+        | ValueSome template ->
+          match!
+            Templates.AddOrUpdate(Templates.TemplateOperation.Add template)
+          with
+          | Ok() -> return 0
+          | Error err ->
+            Logger.log (err, escape = false)
+            return 1
+        | ValueNone ->
+          Logger.log ("We were unable to parse the repository name.")
+
+          Logger.log (
+            "please ensure that the repository name is in the format: [bold blue]username/repository:branch[/]",
+            escape = false
+          )
+
+          return 1
+      | RunTemplateOperation.Update -> return! updateRepo ()
+      | RunTemplateOperation.Update
+      | RunTemplateOperation.Add when template.IsSome -> return! updateRepo ()
+      | RunTemplateOperation.Remove ->
+        match template with
+        | ValueSome template ->
+          Logger.log $"Removing template '{template.ToFullNameWithBranch}'..."
+
+          match Templates.Remove(template) with
+          | Ok() ->
+            Logger.log "Template removed successfully."
+            return 0
+          | Error err ->
+            Logger.log (err, escape = false)
+            return 1
+        | ValueNone ->
+          Logger.log ("We were unable to parse the repository name.")
+
+          Logger.log (
+            "please ensure that the repository name is in the format: [bold blue]username/repository:branch[/]",
+            escape = false
+          )
+
+          return 1
+    }
+
+
+  let runBuild (options: BuildOptions, cancellationToken: CancellationToken) =
+    task {
+      FileSystem.GetDotEnvFilePaths() |> Env.LoadEnvFiles
+
+      ConfigurationManager.UpdateFromCliArgs(?runConfig = options.mode)
+      let config = ConfigurationManager.CurrentConfig
+
+      do! Fable.StartFable(config, cancellationToken)
+
+      if not <| File.Exists($"{FileSystem.EsbuildBinaryPath}") then
+        do! FileSystem.SetupEsbuild(config.esbuild.version, cancellationToken)
+
+      let outDir = UMX.untag config.build.outDir
+
+      try
+        Directory.Delete(outDir, true)
+        Directory.CreateDirectory(outDir) |> ignore
+      with _ ->
+        ()
+
+      PluginRegistry.LoadPlugins(config.esbuild)
+
+      do!
+        Logger.spinner (
+          "Mounting Virtual File System",
+          VirtualFileSystem.Mount config
+        )
+
+      let tempDirectory = VirtualFileSystem.CopyToDisk() |> UMX.tag<SystemPath>
+
+      Logger.log (
+        $"Copying Processed files to {tempDirectory}",
+        target = PrefixKind.Build
+      )
+
+      use fs = new PhysicalFileSystem()
+
+      use browserCtx = new BrowsingContext()
+
+      let externals = Build.GetExternals(config)
+
+      let index = FileSystem.IndexFile(config.index)
+
+      let document = browserCtx.GetService<IHtmlParser>().ParseDocument index
+
+      let tmp = UMX.untag tempDirectory |> fs.ConvertPathFromInternal
+
+      let css, js = Build.GetEntryPoints(document)
+
+      do!
+        Logger.spinner (
+          "Transpiling CSS and JS Files",
+          Esbuild.Run(config, tmp, fs, (css, js), externals, cancellationToken)
+        )
+        :> Task
+
+      let css =
+        [ yield! css
+          yield!
+            js
+            |> Seq.map (fun p ->
+              Path.ChangeExtension(UMX.untag p, ".css") |> UMX.tag) ]
+
+
+      let outDir =
+        config.build.outDir
+        |> UMX.untag
+        |> Path.GetFullPath
+        |> fs.ConvertPathFromInternal
+
+      // copy any glob files
+      Build.CopyGlobs(config.build, tempDirectory)
+
+      // copy any root files
+      fs.EnumerateFileEntries(tmp, "*.*", SearchOption.TopDirectoryOnly)
+      |> Seq.iter (fun file ->
+        file.CopyTo(UPath.Combine(outDir, file.Name), true) |> ignore)
+
+      let indexContent =
+        Build.GetIndexFile(document, css, js, FileSystem.GetImportMap())
+      // Always copy the index file at the end to avoid
+      // clashing with any index.html file in the root of the virtual file system
+      fs.WriteAllText(UPath.Combine(outDir, "index.html"), indexContent)
+
+      Logger.log $"Cleaning up temp dir {tempDirectory}"
+
+      try
+        Directory.Delete(UMX.untag tempDirectory, true)
+      with ex ->
+        Logger.log ($"Failed to delete {tempDirectory}", ex = ex)
+
+      if config.build.emitEnvFile then
+        Logger.log "Writing Env File"
+        Build.EmitEnvFile(config)
+
+      if options.enablePreview then
+        let app = Server.GetStaticServer(config)
+        do! app.StartAsync(cancellationToken)
+
+        app.Urls
+        |> Seq.iter (fun url ->
+          Logger.log ($"Listening at: {url}", target = Serve))
+
+        while not cancellationToken.IsCancellationRequested do
+          do! Async.Sleep(1000)
+
+        do! app.StopAsync(cancellationToken)
+
+      return 0
+    }
+
+  let runServe (options: ServeOptions, cancellationToken: CancellationToken) =
+    task {
+      FileSystem.GetDotEnvFilePaths() |> Env.LoadEnvFiles
+
+      let cliArgs =
+        [ match options.port with
+          | Some port -> DevServerField.Port port
+          | None -> ()
+          match options.host with
+          | Some host -> DevServerField.Host host
+          | None -> ()
+          match options.ssl with
+          | Some ssl -> DevServerField.UseSSL ssl
+          | None -> ()
+          // Don't minify sources in dev mode
+          DevServerField.MinifySources false ]
+
+      ConfigurationManager.UpdateFromCliArgs(
+        ?runConfig = options.mode,
+        serverOptions = cliArgs
+      )
+
+
+      let config = ConfigurationManager.CurrentConfig
+
+      let fableEvents =
+        match config.fable with
+        | Some fable ->
+          Fable.Observe(fable, cancellationToken = cancellationToken)
+        | None ->
+          let sub = Subject.replay
+          sub.OnNext(FableEvent.WaitingForChanges)
+          sub
+
+      use _ =
+        fableEvents
+        |> Observable.subscribeSafe (fun events ->
+          match events with
+          | FableEvent.Log msg -> Logger.log (msg.EscapeMarkup())
+          | FableEvent.ErrLog msg ->
+            Logger.log $"[bold red]{msg.EscapeMarkup()}[/]"
+          | FableEvent.WaitingForChanges -> ())
+
+      do! FsMonitor.FirstCompileDone true fableEvents
+
+      do! FileSystem.SetupEsbuild(config.esbuild.version, cancellationToken)
+
+      PluginRegistry.LoadPlugins(config.esbuild)
+
+      do! VirtualFileSystem.Mount(config)
+
+      let perlaChanges =
+        FileSystem.ObservePerlaFiles(UMX.untag config.index, cancellationToken)
+
+      let fileChanges =
+        FsMonitor.FileChanges(
+          UMX.untag config.index,
+          config.mountDirectories,
+          perlaChanges,
+          config.plugins
+        )
+
+      // TODO: Grab these from esbuild
+      let compilerErrors = Observable.empty
+
+      let mutable app = Server.GetServerApp(config, fileChanges, compilerErrors)
+      do! app.StartAsync(cancellationToken)
+
+      app.Urls
+      |> Seq.iter (fun url ->
+        Logger.log ($"Listening at: {url}", target = Serve))
+
+      perlaChanges
+      |> Observable.throttle (TimeSpan.FromMilliseconds(500.))
+      |> Observable.choose (function
+        | PerlaFileChange.PerlaConfig -> Some()
+        | _ -> None)
+      |> Observable.map (fun _ -> app.StopAsync() |> Async.AwaitTask)
+      |> Observable.switchAsync
+      |> Observable.add (fun _ ->
+        ConfigurationManager.UpdateFromFile()
+        app <- Server.GetServerApp(config, fileChanges, compilerErrors)
+        app.StartAsync(cancellationToken) |> ignore)
+
+      while not cancellationToken.IsCancellationRequested do
+        do! Async.Sleep(TimeSpan.FromSeconds(1.))
+
+      return 0
+    }
+
+  let runTesting
+    (
+      options: TestingOptions,
+      cancellationToken: CancellationToken
+    ) =
+    task {
+      FileSystem.GetDotEnvFilePaths() |> Env.LoadEnvFiles
+
+      ConfigurationManager.UpdateFromCliArgs(
+        testingOptions =
+          [ match options.browsers with
+            | Some value -> TestingField.Browsers value
+            | None -> ()
+            match options.files with
+            | Some value -> TestingField.Includes value
+            | None -> ()
+            match options.skip with
+            | Some value -> TestingField.Excludes value
+            | None -> ()
+            match options.watch with
+            | Some value -> TestingField.Watch value
+            | None -> ()
+            match options.headless with
+            | Some value -> TestingField.Headless value
+            | None -> ()
+            match options.browserMode with
+            | Some value -> TestingField.BrowserMode value
+            | None -> () ]
+      )
+
+      let config =
+        { ConfigurationManager.CurrentConfig with
+            mountDirectories =
+              ConfigurationManager.CurrentConfig.mountDirectories
+              |> Map.add
+                (UMX.tag<ServerUrl> "/tests")
+                (UMX.tag<UserPath> "./tests") }
+
+      let isWatch = config.testing.watch
+
+      let! dependencies = Setup.EnsureDependencies(config, cancellationToken)
+
+      let fableEvents =
+        match config.testing.fable with
+        | Some fable -> Fable.Observe(fable, isWatch)
+        | None -> Observable.single FableEvent.WaitingForChanges
+
+      fableEvents
+      |> Observable.add (fun events ->
+        match events with
+        | FableEvent.Log msg -> Logger.log (msg.EscapeMarkup())
+        | FableEvent.ErrLog msg ->
+          Logger.log $"[bold red]{msg.EscapeMarkup()}[/]"
+        | FableEvent.WaitingForChanges -> ())
+
+      do! FsMonitor.FirstCompileDone isWatch fableEvents
+
+
+      PluginRegistry.LoadPlugins config.esbuild
+
+      do! VirtualFileSystem.Mount config
+
+      let perlaChanges =
+        FileSystem.ObservePerlaFiles(UMX.untag config.index, cancellationToken)
+
+      let fileChanges =
+        FsMonitor.FileChanges(
+          UMX.untag config.index,
+          config.mountDirectories,
+          perlaChanges,
+          config.plugins
+        )
+      // TODO: Grab these from esbuild
+      let compilerErrors = Observable.empty
+
+      let config =
+        { config with
+            devServer =
+              { config.devServer with
+                  liveReload = isWatch } }
+
+      let events = Subject<TestEvent>.broadcast
+
+      let mutable app =
+        Server.GetTestingApp(
+          config,
+          dependencies,
+          events,
+          fileChanges,
+          compilerErrors,
+          config.testing.includes
+        )
+      // Keep this before initializing the server
+      // otherwise it will always say that the port is occupied
+      let http, _ =
+        Server.GetServerURLs
+          config.devServer.host
+          config.devServer.port
+          config.devServer.useSSL
+
+      do! app.StartAsync(cancellationToken)
+
+      perlaChanges
+      |> Observable.choose (function
+        | PerlaFileChange.PerlaConfig -> Some()
+        | _ -> None)
+      |> Observable.map (fun _ -> app.StopAsync() |> Async.AwaitTask)
+      |> Observable.switchAsync
+      |> Observable.map (fun _ ->
+        ConfigurationManager.UpdateFromFile()
+        app <- Server.GetServerApp(config, fileChanges, compilerErrors)
+        app.StartAsync(cancellationToken) |> Async.AwaitTask)
+      |> Observable.switchAsync
+      |> Observable.add ignore
+
+      use! pl = Playwright.CreateAsync()
+
+      let testConfig = config.testing
+
+      if not isWatch then
+        do!
+          Testing.RunOnce(
+            pl,
+            testConfig.browserMode,
+            testConfig.browsers,
+            testConfig.headless,
+            http
+          )
+
+        events.OnCompleted()
+
+        events
+        |> Observable.toEnumerable
+        |> Seq.toList
+        |> Testing.BuildReport
+        |> Print.Report
+
+        return 0
+      else
+        let browser = config.testing.browsers |> Seq.head
+        let fileChanges = fileChanges |> Observable.map ignore
+
+        do!
+          Testing.LiveRun(
+            pl,
+            browser,
+            testConfig.headless,
+            http,
+            fileChanges,
+            events,
+            cancellationToken
+          )
+
+        events.OnCompleted()
+
+        events
+        |> Observable.toEnumerable
+        |> Seq.toList
+        |> Testing.BuildReport
+        |> Print.Report
+
+        return 0
+    }
+
+  let runSearchPackage
+    (
+      options: SearchOptions,
+      cancellationToken: CancellationToken
+    ) =
+    task {
+      do! Dependencies.Search(options.package, options.page)
+      return 0
+    }
+
+  let runShowPackage
+    (
+      options: ShowPackageOptions,
+      cancellationToken: CancellationToken
+    ) =
+    task {
+      do! Dependencies.Show(options.package)
+      return 0
+    }
+
+  let runAddPackage
+    (
+      options: AddPackageOptions,
+      cancellationToken: CancellationToken
+    ) =
+    task {
+      ConfigurationManager.UpdateFromCliArgs(
+        ?runConfig = options.mode,
+        ?provider = options.source
+      )
+
+      let config = ConfigurationManager.CurrentConfig
+      let package, packageVersion = parsePackageName options.package
+
+      match options.alias with
+      | Some _ ->
+        Logger.log (
+          $"[bold yellow]Aliases management will change in the future, they will be ignored if this warning appears[/]",
+          escape = false
+        )
+      | None -> ()
+
+      let version =
+        match packageVersion with
+        | Some version -> $"@{version}"
+        | None -> ""
+
+      let importMap = FileSystem.GetImportMap()
+      Logger.log "Updating Import Map..."
+
+      let! map =
+        Logger.spinner (
+          $"Adding: [bold yellow]{package}{version}[/]",
+          Dependencies.Add(
+            $"{package}{version}",
+            importMap,
+            provider = config.provider,
+            runConfig = config.runConfiguration
+          )
+        )
+
+      match map with
+      | Ok map ->
+        let newDep =
+          { name = package
+            version = packageVersion
+            alias = options.alias }
+
+        let dependencies, devDependencies =
+          let config =
+            match config.runConfiguration with
+            | RunConfiguration.Development ->
+              { config with
+                  devDependencies = [ yield! config.devDependencies; newDep ] }
+            | RunConfiguration.Production ->
+              { config with
+                  dependencies = [ yield! config.dependencies; newDep ] }
+
+          let deps, devDeps =
+            Dependencies.LocateDependenciesFromMapAndConfig(map, config)
+
+          PerlaWritableField.Dependencies deps,
+          PerlaWritableField.DevDependencies devDeps
+
+        ConfigurationManager.WriteFieldsToFile(
+          [ dependencies; devDependencies ]
+        )
+
+        FileSystem.WriteImportMap(map) |> ignore
+        return 0
+      | Error err ->
+        Logger.log ($"[bold red]{err}[/]", escape = false)
+        return 1
+    }
+
+  let runRemovePackage
+    (
+      options: RemovePackageOptions,
+      cancellationToken: CancellationToken
+    ) =
+    task {
+      let name = options.package
+      Logger.log ($"Removing: [red]{name}[/]", escape = false)
+      let config = ConfigurationManager.CurrentConfig
+
+      let map = FileSystem.GetImportMap()
+
+      let dependencies, devDependencies =
+        let deps, devDeps =
+          Dependencies.LocateDependenciesFromMapAndConfig(
+            map,
+            { config with
+                dependencies =
+                  config.dependencies |> Seq.filter (fun d -> d.name <> name)
+                devDependencies =
+                  config.devDependencies |> Seq.filter (fun d -> d.name <> name) }
+          )
+
+        deps, devDeps
+
+      ConfigurationManager.WriteFieldsToFile(
+        [ PerlaWritableField.Dependencies dependencies
+          PerlaWritableField.DevDependencies devDependencies ]
+      )
+
+      let packages =
+        match config.runConfiguration with
+        | RunConfiguration.Production ->
+          dependencies |> Seq.map (fun f -> f.AsVersionedString)
+        | RunConfiguration.Development ->
+          [ yield! dependencies; yield! devDependencies ]
+          |> Seq.map (fun f -> f.AsVersionedString)
+
+      match!
+        Dependencies.Restore(
+          packages,
+          Provider.Jspm,
+          runConfig = config.runConfiguration
+        )
+      with
+      | Ok map ->
+        FileSystem.WriteImportMap(map) |> ignore
+        return 0
+      | Error err ->
+        Logger.log $"[bold red]{err}[/]"
+        return 1
+    }
+
+  let runListPackages (options: ListPackagesOptions) =
+    task {
+      let config = ConfigurationManager.CurrentConfig
+
+      match options.format with
+      | ListFormat.HumanReadable ->
+        Logger.log (
+          "[bold green]Installed packages[/] [yellow](alias: packageName@version)[/]\n",
+          escape = false
+        )
+
+        let prodTable =
+          dependencyTable (config.dependencies, "Production Dependencies")
+
+        let devTable =
+          dependencyTable (config.devDependencies, "Development Dependencies")
+
+        AnsiConsole.Write(prodTable)
+        AnsiConsole.WriteLine()
+        AnsiConsole.Write(devTable)
+
+      | ListFormat.TextOnly ->
+        let inline aliasDependency (dep: Dependency) =
+          let name =
+            match dep.alias with
+            | Some alias -> $"{alias}:{dep.name}"
+            | None -> dep.name
+
+          name, dep.version
+
+        let depsMap =
+          config.dependencies |> Seq.map aliasDependency |> Map.ofSeq
+
+        let devDepsMap =
+          config.devDependencies |> Seq.map aliasDependency |> Map.ofSeq
+
+        {| dependencies = depsMap
+           devDependencies = devDepsMap |}
+        |> Json.ToText
+        |> AnsiConsole.Write
+
+      return 0
+    }
+
+  let runRestoreImportMap
+    (
+      options: RestoreOptions,
+      cancellationToken: CancellationToken
+    ) =
+    task {
+      ConfigurationManager.UpdateFromCliArgs(
+        ?runConfig = options.mode,
+        ?provider = options.source
+      )
+
+      let config = ConfigurationManager.CurrentConfig
+
+      Logger.log "Regenerating import map..."
+
+      let packages =
+        [ yield! config.dependencies
+          match config.runConfiguration with
+          | RunConfiguration.Development -> yield! config.devDependencies
+          | RunConfiguration.Production -> () ]
+        |> List.map (fun d -> d.AsVersionedString)
+        // deduplicate repeated strings
+        |> set
+
+      match!
+        Logger.spinner (
+          "Fetching dependencies...",
+          Dependencies.Restore(packages, provider = config.provider)
+        )
+      with
+      | Ok response -> FileSystem.WriteImportMap(response) |> ignore
+      | Error err ->
+        Logger.log $"An error happened restoring the import map:\n{err}"
+
+      return 0
+    }
+
+  let runDescribePerla (options: DescribeOptions) =
+    task {
+      let { properties = props
+            current = current } =
+        options
+
+      let config = ConfigurationManager.CurrentConfig
+
+      let table = Table().AddColumn("Property")
+
+      AnsiConsole.Write(FigletText("Perla.json"))
+      let descriptions = FileSystem.DescriptionsFile
+
+      match props, current with
+      | Some props, true ->
+        table.AddColumns("Value", "Explanation") |> ignore
+
+        for prop in props do
+          let description =
+            descriptions.Value |> Map.tryFind prop |> Option.defaultValue ""
+
+          match prop with
+          | TopLevelProp prop ->
+            table.AddRow(
+              Text(prop),
+              config[prop] |> Option.defaultValue (Text ""),
+              Text(description)
+            )
+            |> ignore
+          | NestedProp props ->
+            table.AddRow(
+              Text(prop),
+              config[props] |> Option.defaultValue (Text ""),
+              Text(description)
+            )
+            |> ignore
+          | TripleNestedProp props ->
+            table.AddRow(
+              Text(prop),
+              config[props] |> Option.defaultValue (Text ""),
+              Text(description)
+            )
+            |> ignore
+          | InvalidPropPath ->
+            table.AddRow(prop, "", "This is not a valid property") |> ignore
+
+      | Some props, false ->
+        table.AddColumns("Description", "Default Value") |> ignore
+
+        for prop in props do
+          let description =
+            descriptions.Value |> Map.tryFind prop |> Option.defaultValue ""
+
+          match prop with
+          | TopLevelProp prop ->
+            table.AddRow(
+              Text(prop),
+              Text(description),
+              Defaults.PerlaConfig[prop] |> Option.defaultValue (Text "")
+            )
+            |> ignore
+          | NestedProp props ->
+            table.AddRow(
+              Text(prop),
+              Text(description),
+              Defaults.PerlaConfig[props] |> Option.defaultValue (Text "")
+            )
+            |> ignore
+          | TripleNestedProp props ->
+            table.AddRow(
+              Text(prop),
+              Text(description),
+              Defaults.PerlaConfig[props] |> Option.defaultValue (Text "")
+            )
+            |> ignore
+          | InvalidPropPath ->
+            table.AddRow(
+              Text(
+                prop,
+                Style(foreground = Color.Yellow, background = Color.Yellow)
+              ),
+              Text(""),
+              Text(
+                "This is not a valid property",
+                Style(foreground = Color.Yellow)
+              )
+            )
+            |> ignore
+
+      | None, false ->
+        table.AddColumn("Description") |> ignore
+
+        for KeyValue(key, value) in descriptions.Value do
+          table.AddRow(key, value) |> ignore
+      | None, true ->
+        table.AddColumns("Current Value", "Description") |> ignore
+
+        for KeyValue(key, description) in descriptions.Value do
+          match key with
+          | TopLevelProp prop ->
+            table.AddRow(
+              Text(prop),
+              Defaults.PerlaConfig[prop] |> Option.defaultValue (Text ""),
+              Text(description)
+            )
+            |> ignore
+          | NestedProp props ->
+            table.AddRow(
+              Text(key),
+              Defaults.PerlaConfig[props] |> Option.defaultValue (Text ""),
+              Text(description)
+            )
+            |> ignore
+          | TripleNestedProp props ->
+            table.AddRow(
+              Text(key),
+              Defaults.PerlaConfig[props] |> Option.defaultValue (Text ""),
+              Text(description)
+            )
+            |> ignore
+          | InvalidPropPath ->
+            table.AddRow(
+              Text(
+                key,
+                Style(foreground = Color.Yellow, background = Color.Yellow)
+              ),
+              Text(""),
+              Text(
+                "This is not a valid property",
+                Style(foreground = Color.Yellow)
+              )
+            )
+            |> ignore
+
+      table.Caption <-
+        TableTitle(
+          "For more information visit: https://perla-docs.web.app/#/v1/docs/reference/perla"
+        )
+
+      table.DoubleBorder() |> AnsiConsole.Write
+      return 0
+    }

--- a/src/Perla/Handlers.fsi
+++ b/src/Perla/Handlers.fsi
@@ -1,0 +1,100 @@
+﻿namespace Perla.Handlers
+
+open System.Threading
+open System.Threading.Tasks
+
+open Perla.Types
+open Perla.PackageManager.Types
+
+[<Struct; RequireQualifiedAccess>]
+type ListFormat =
+    | HumanReadable
+    | TextOnly
+
+type ServeOptions =
+    { port: int option
+      host: string option
+      mode: RunConfiguration option
+      ssl: bool option }
+
+type BuildOptions =
+    { mode: RunConfiguration option
+      enablePreview: bool
+      enablePreloads: bool
+      rebuildImportMap: bool }
+
+type SetupOptions =
+    { skipPrompts: bool
+      skipPlaywright: bool }
+
+type SearchOptions = { package: string; page: int }
+
+type ShowPackageOptions = { package: string }
+
+type ListTemplatesOptions = { format: ListFormat }
+
+type AddPackageOptions =
+    { package: string
+      version: string option
+      source: Provider option
+      mode: RunConfiguration option
+      alias: string option }
+
+type RemovePackageOptions =
+    { package: string
+      alias: string option }
+
+type ListPackagesOptions = { format: ListFormat }
+
+[<RequireQualifiedAccess; Struct>]
+type RunTemplateOperation =
+    | Add
+    | Update
+    | Remove
+    | List of ListFormat
+
+type TemplateRepositoryOptions =
+    { fullRepositoryName: string
+      operation: RunTemplateOperation }
+
+type ProjectOptions =
+    { projectName: string
+      byTemplateName: string option
+      byId: string option
+      byShortName: string option }
+
+type RestoreOptions =
+    { source: Provider option
+      mode: RunConfiguration option }
+
+type TestingOptions =
+    { browsers: Browser seq option
+      files: string seq option
+      skip: string seq option
+      watch: bool option
+      headless: bool option
+      browserMode: BrowserMode option }
+
+type DescribeOptions =
+    { properties: string[] option
+      current: bool }
+
+module Handlers =
+
+    val runSetup: options: SetupOptions * cancellationToken: CancellationToken -> Task<int>
+    val runNew: options: ProjectOptions * cancellationToken: CancellationToken -> Task<int>
+    val runTemplate: options: TemplateRepositoryOptions * cancellationToken: CancellationToken -> Task<int>
+
+    val runBuild: options: BuildOptions * cancellationToken: CancellationToken -> Task<int>
+    val runServe: options: ServeOptions * cancellationToken: CancellationToken -> Task<int>
+    val runTesting: options: TestingOptions * cancellationToken: CancellationToken -> Task<int>
+
+    val runSearchPackage: options: SearchOptions * cancellationToken: CancellationToken -> Task<int>
+    val runShowPackage: options: ShowPackageOptions * cancellationToken: CancellationToken -> Task<int>
+
+    val runAddPackage: options: AddPackageOptions * cancellationToken: CancellationToken -> Task<int>
+    val runRemovePackage: options: RemovePackageOptions * cancellationToken: CancellationToken -> Task<int>
+    val runListPackages: options: ListPackagesOptions -> Task<int>
+    val runRestoreImportMap: options: RestoreOptions * cancellationToken: CancellationToken -> Task<int>
+
+    val runDescribePerla: options: DescribeOptions -> Task<int>

--- a/src/Perla/Json.fs
+++ b/src/Perla/Json.fs
@@ -40,6 +40,45 @@ let DefaultJsonDocumentOptions () =
     CommentHandling = JsonCommentHandling.Skip
   )
 
+module TemplateDecoders =
+  type DecodedTemplateConfigItem =
+    { id: string
+      name: string
+      path: string<SystemPath>
+      shortName: string
+      description: string option }
+
+  type DecodedTemplateConfiguration =
+    { name: string
+      group: string
+      templates: DecodedTemplateConfigItem seq
+      author: string option
+      license: string option
+      description: string option
+      repositoryUrl: string option }
+
+  let TemplateConfigItemDecoder: Decoder<DecodedTemplateConfigItem> =
+    Decode.object (fun get ->
+      { id = get.Required.Field "id" Decode.string
+        name = get.Required.Field "name" Decode.string
+        path = get.Required.Field "path" Decode.string |> UMX.tag<SystemPath>
+        shortName = get.Required.Field "shortName" Decode.string
+        description = get.Optional.Field "description" Decode.string })
+
+  let TemplateConfigurationDecoder: Decoder<DecodedTemplateConfiguration> =
+    Decode.object (fun get ->
+      { name = get.Required.Field "name" Decode.string
+        group = get.Required.Field "group" Decode.string
+        templates =
+          get.Required.Field
+            "templates"
+            (Decode.array TemplateConfigItemDecoder)
+        author = get.Optional.Field "author" Decode.string
+        license = get.Optional.Field "license" Decode.string
+        description = get.Optional.Field "description" Decode.string
+        repositoryUrl = get.Optional.Field "repositoryUrl" Decode.string })
+
+
 module ConfigDecoders =
 
   type DecodedFableConfig =

--- a/src/Perla/Json.fsi
+++ b/src/Perla/Json.fsi
@@ -11,6 +11,30 @@ open Thoth.Json.Net
 
 open FSharp.UMX
 
+
+
+module TemplateDecoders =
+    type DecodedTemplateConfigItem =
+        { id: string
+          name: string
+          path: string<SystemPath>
+          shortName: string
+          description: string option }
+
+    type DecodedTemplateConfiguration =
+        { name: string
+          group: string
+          templates: DecodedTemplateConfigItem seq
+          author: string option
+          license: string option
+          description: string option
+          repositoryUrl: string option }
+
+    val TemplateConfigItemDecoder: Decoder<DecodedTemplateConfigItem>
+
+    val TemplateConfigurationDecoder: Decoder<DecodedTemplateConfiguration>
+
+
 module ConfigDecoders =
 
 

--- a/src/Perla/Library.fs
+++ b/src/Perla/Library.fs
@@ -42,7 +42,7 @@ module Lib =
     | _ -> ValueNone
 
   let parseFullRepositoryName (value: string) =
-    let regex = new Regex(@"^([-_\w\d]+)\/([-_\w\d]+):?([\w\d-_]+)?$")
+    let regex = Regex(@"^([-_\w\d]+)\/([-_\w\d]+):?([\w\d-_]+)?$")
 
     match value with
     | ParseRegex regex [ username; repository; branch ] ->
@@ -105,7 +105,7 @@ module Lib =
         let parts = name.Split("@")
         let version = getVersion parts
 
-        $"@{parts.[0]}", version
+        $"@{parts[0]}", version
       else
         $"@{name}", None
     | Package name ->
@@ -113,7 +113,7 @@ module Lib =
         let parts = name.Split("@")
 
         let version = getVersion parts
-        parts.[0], version
+        parts[0], version
       else
         name, None
 

--- a/src/Perla/Perla.fsproj
+++ b/src/Perla/Perla.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>perla</ToolCommandName>
@@ -50,6 +50,9 @@
     <Compile Include="Server.fs" />
     <Compile Include="Configuration.fsi" />
     <Compile Include="Configuration.fs" />
+    <Compile Include="Handlers.fsi" />
+    <Compile Include="Handlers.fs" />
+    <Compile Include="Commands.fsi" />
     <Compile Include="Commands.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/src/Perla/Program.fs
+++ b/src/Perla/Program.fs
@@ -1,9 +1,12 @@
 ﻿// Learn more about F# at http://docs.microsoft.com/dotnet/fsharp
+
+open System.Threading.Tasks
 open System.CommandLine.Invocation
 open System.CommandLine.Builder
+
 open FSharp.SystemCommandLine
+
 open Perla
-open System.Threading.Tasks
 
 [<EntryPoint>]
 let main argv =
@@ -24,22 +27,19 @@ let main argv =
       pipeline.UseTokenReplacer(fun _ _ _ -> false) |> ignore)
 
     addCommands
-      [ Commands.Serve
+      [ Commands.Setup
+        Commands.Template
+        Commands.Describe
         Commands.Build
-        Commands.Setup
-        Commands.SearchPackages
-        Commands.ShowPackage
-        Commands.RemovePackage
-        Commands.AddPackage
-        Commands.ListDependencies
-        Commands.Restore
-        Commands.AddTemplate
-        Commands.UpdateTemplate
-        Commands.ListTemplates
-        Commands.RemoveTemplate
-        Commands.NewProject
+        Commands.Serve
         Commands.Test
-        Commands.Describe ]
+        Commands.SearchPackage
+        Commands.ShowPackage
+        Commands.AddPackage
+        Commands.RemovePackage
+        Commands.ListPackages
+        Commands.RestoreImportMap
+        Commands.NewProject ]
   }
   |> Async.AwaitTask
   |> Async.RunSynchronously

--- a/src/Perla/Program.fs
+++ b/src/Perla/Program.fs
@@ -7,6 +7,7 @@ open System.CommandLine.Builder
 open FSharp.SystemCommandLine
 
 open Perla
+open Perla.Commands
 
 [<EntryPoint>]
 let main argv =

--- a/src/Perla/Scaffolding.fs
+++ b/src/Perla/Scaffolding.fs
@@ -10,9 +10,14 @@ open Perla.FileSystem
 open FSharp.UMX
 open Perla.Extensibility
 
+open Perla.Json.TemplateDecoders
+open Perla.Units
+open Thoth.Json.Net
+
 
 module Scaffolding =
   open Units
+  open FsToolkit.ErrorHandling
 
   [<Literal>]
   let ScaffoldConfiguration = "TemplateConfiguration"
@@ -27,12 +32,35 @@ module Scaffolding =
     | None -> None
 
   [<CLIMutable>]
+  type TemplateItem =
+    { _id: ObjectId
+      parent: ObjectId
+      name: string
+      group: string
+      shortName: string
+      description: string option
+      fullPath: string<SystemPath> }
+
+  type TemplateConfigurationItem =
+    { childId: ObjectId
+      name: string
+      shortName: string
+      description: string }
+
+  [<CLIMutable>]
   type PerlaTemplateRepository =
     { _id: ObjectId
       username: string
       repository: string
       branch: string
       path: string<SystemPath>
+      name: string
+      description: string
+      author: string
+      license: string
+      repositoryUrl: string
+      group: string
+      templates: TemplateConfigurationItem seq
       createdAt: DateTime
       updatedAt: Nullable<DateTime> }
 
@@ -60,19 +88,37 @@ module Scaffolding =
     | Repository of repository: string
     | FullName of username: string * repository: string
 
-  let private templatesdb =
+  [<RequireQualifiedAccess>]
+  type QuickAccessSearch =
+    | Id of ObjectId
+    | Name of string
+    | Group of string
+    | ShortName of string
+    | Parent of ObjectId
+
+  let Database =
     lazy
       (new LiteDatabase(
         $"Filename='{UMX.untag FileSystem.Database}';Connection='shared'"
       ))
 
-  let private repositories =
+  let RepositoriesCol =
     lazy
-      (let database = templatesdb.Value
+      (let database = Database.Value
        let repo = database.GetCollection<PerlaTemplateRepository>()
 
        repo.EnsureIndex(fun template -> template.username) |> ignore
        repo.EnsureIndex(fun template -> template.repository) |> ignore
+       repo)
+
+  let TemplatesCol =
+    lazy
+      (let database = Database.Value
+       let repo = database.GetCollection<TemplateItem>()
+       repo.EnsureIndex(fun template -> template.parent) |> ignore
+       repo.EnsureIndex(fun template -> template.group, true) |> ignore
+       repo.EnsureIndex(fun template -> template.name) |> ignore
+       repo.EnsureIndex(fun template -> template.shortName) |> ignore
        repo)
 
   let downloadAndExtract (user: string, repository: string, branch: string) =
@@ -85,25 +131,110 @@ module Scaffolding =
       return FileSystem.ExtractTemplateZip (user, repository, branch) stream
     }
 
+  let buildTemplateItems
+    (templateItems: DecodedTemplateConfigItem seq)
+    parentId
+    parentGroup
+    =
+    templateItems
+    |> Seq.map (fun templateItem ->
+      { _id = ObjectId.NewObjectId()
+        parent = parentId
+        name = templateItem.name
+        group = $"{parentGroup}.{templateItem.id}"
+        shortName = templateItem.shortName
+        description = templateItem.description
+        fullPath = templateItem.path })
+
+  let buildTemplateConfigurationItems
+    (templates: TemplateItem seq)
+    =
+    templates
+    |> Seq.map (fun item ->
+      { childId = item._id
+        name = item.name
+        shortName = item.shortName
+        description =
+          item.description |> Option.defaultValue "No Description Provided" })
+
+  let buildTemplateRepository
+    (options:
+      {| id: ObjectId
+         user: string
+         repository: string
+         branch: string
+         path: string<SystemPath>
+         name: string
+         author: string
+         license: string
+         repositoryUrl: string
+         group: string
+         templates: seq<TemplateConfigurationItem>
+         description: string
+         updatedAt: Nullable<DateTime> |})
+    =
+
+    { _id = options.id
+      username = options.user
+      repository = options.repository
+      branch = options.branch
+      path = options.path
+      createdAt = DateTime.Now
+      updatedAt = options.updatedAt
+      name = options.name
+      description = options.description
+      author = options.author
+      license = options.license
+      repositoryUrl = options.repositoryUrl
+      group = options.group
+      templates = options.templates }
+
   type Templates =
 
-    static member List() =
-      repositories.Value.FindAll() |> Seq.toList
+    static member ListRepositories() =
+      RepositoriesCol.Value.FindAll() |> Seq.toList
+
+    static member ListTemplateItems() =
+      TemplatesCol.Value.FindAll() |> Seq.toList
 
     static member Add(user, repository, branch) =
-      task {
-        let! path = downloadAndExtract (user, repository, branch)
+      taskResult {
+        let! result = downloadAndExtract (user, repository, branch)
+        let path, config = result
+        let! config = config
+        let id = ObjectId.NewObjectId()
+
+        let templateItems: TemplateItem seq =
+          buildTemplateItems config.templates id config.group
 
         let template =
-          { _id = ObjectId.NewObjectId()
-            username = user
-            repository = repository
-            branch = branch
-            path = path
-            createdAt = DateTime.Now
-            updatedAt = Nullable() }
+          buildTemplateRepository
+            {| id = id
+               user = user
+               repository = repository
+               branch = branch
+               path = path
+               updatedAt = Nullable()
+               name = config.name
+               description =
+                config.description
+                |> Option.defaultValue "No description provided"
+               author =
+                config.author |> Option.defaultValue "No author provided"
+               license =
+                config.license |> Option.defaultValue "No license provided"
+               repositoryUrl =
+                config.repositoryUrl
+                |> Option.defaultValue
+                  $"https://github.com/{user}/{repository}/tree/{branch}"
+               group = config.group
+               templates = buildTemplateConfigurationItems templateItems |}
 
-        return repositories.Value.Insert(template).AsObjectId
+        let parentId = RepositoriesCol.Value.Insert(template).AsObjectId
+
+        TemplatesCol.Value.InsertBulk templateItems |> ignore
+
+        return parentId
       }
 
     /// <summary>
@@ -113,7 +244,7 @@ module Scaffolding =
     /// </summary>
     /// <param name="name">Full name of the template in the Username/Repository scheme</param>
     static member Exists(name: TemplateSearchKind) =
-      repositories.Value.Exists(fun tplRepository ->
+      RepositoriesCol.Value.Exists(fun tplRepository ->
         match name with
         | TemplateSearchKind.Id id -> tplRepository._id = id
         | TemplateSearchKind.Username name -> tplRepository.username = name
@@ -131,7 +262,7 @@ module Scaffolding =
     static member FindOne
       (name: TemplateSearchKind)
       : PerlaTemplateRepository option =
-      let templates = repositories.Value
+      let templates = RepositoriesCol.Value
 
       let result =
         match name with
@@ -139,27 +270,82 @@ module Scaffolding =
         | TemplateSearchKind.Username username ->
           templates
             .Query()
-            .Where(fun tplRepo -> tplRepo.username = username)
+            .Where(fun tplRepo ->
+              tplRepo.username.Equals(
+                username,
+                StringComparison.InvariantCultureIgnoreCase
+              ))
             .SingleOrDefault()
         | TemplateSearchKind.Repository repository ->
           templates
             .Query()
-            .Where(fun tplRepo -> tplRepo.repository = repository)
+            .Where(fun tplRepo ->
+              tplRepo.repository.Equals(
+                repository,
+                StringComparison.InvariantCultureIgnoreCase
+              ))
             .SingleOrDefault()
         | TemplateSearchKind.FullName(username, repository) ->
           templates
             .Query()
             .Where(fun tplRepo ->
-              tplRepo.username = username && tplRepo.repository = repository)
+              tplRepo.username.Equals(
+                username,
+                StringComparison.InvariantCultureIgnoreCase
+              )
+              && tplRepo.repository.Equals(
+                repository,
+                StringComparison.InvariantCultureIgnoreCase
+              ))
             .SingleOrDefault()
 
-      match box result with
-      | :? PerlaTemplateRepository as repo -> Some repo
-      | null
-      | _ -> None
+      Option.ofNull result
+
+    static member FindTemplateItems(searchParams: QuickAccessSearch) =
+      let templatesCol = TemplatesCol.Value
+
+      let result =
+        match searchParams with
+        | QuickAccessSearch.Id id ->
+          templatesCol.FindById(id)
+          |> Option.ofNull
+          |> Option.map (fun tpl -> [| tpl |])
+          |> Option.defaultWith (fun _ -> Array.empty)
+
+        | QuickAccessSearch.Name name ->
+          templatesCol
+            .Query()
+            .Where(fun tpl ->
+              tpl.name.Equals(
+                name,
+                StringComparison.InvariantCultureIgnoreCase
+              ))
+            .ToArray()
+        | QuickAccessSearch.Group group ->
+          templatesCol
+            .Query()
+            .Where(fun tpl ->
+              tpl.group.Equals(
+                group,
+                StringComparison.InvariantCultureIgnoreCase
+              ))
+            .ToArray()
+        | QuickAccessSearch.ShortName shortName ->
+          templatesCol
+            .Query()
+            .Where(fun tpl ->
+              tpl.shortName.Equals(
+                shortName,
+                StringComparison.InvariantCultureIgnoreCase
+              ))
+            .ToArray()
+        | QuickAccessSearch.Parent id ->
+          templatesCol.Query().Where(fun tpl -> tpl.parent.Equals(id)).ToArray()
+
+      result |> List.ofArray
 
     static member Update(template: PerlaTemplateRepository) =
-      task {
+      taskResult {
         match
           Templates.FindOne(
             TemplateSearchKind.FullName(template.username, template.repository)
@@ -180,21 +366,62 @@ module Scaffolding =
               )
               |> Async.AwaitTask
 
+            let path, config = path
+            let! config = config
+
+            let templateItems: TemplateItem seq =
+              buildTemplateItems config.templates repo._id config.group
+
+
             let updated =
-              repositories.Value.Update(repo._id, { updated with path = path })
+              RepositoriesCol.Value.Update(
+                repo._id,
+                { updated with
+                    path = path
+                    name = config.name
+                    description =
+                      config.description
+                      |> Option.defaultValue "No description provided"
+                    author =
+                      config.author |> Option.defaultValue "No author provided"
+                    license =
+                      config.license
+                      |> Option.defaultValue "No license provided"
+                    repositoryUrl =
+                      config.repositoryUrl
+                      |> Option.defaultValue
+                        $"https://github.com/{updated.ToFullName}/tree/{updated.branch}"
+                    group = config.group
+                    templates =
+                      buildTemplateConfigurationItems templateItems }
+              )
+
+            if updated then
+              // cleanup existing templates from the database
+              TemplatesCol.Value.DeleteMany(fun template ->
+                template.parent = repo._id)
+              |> ignore
+
+              // Insert the updated templates
+              TemplatesCol.Value.InsertBulk templateItems |> ignore
 
             return updated
           with ex ->
             Logger.Logger.log ("We could not update the template", ex = ex)
-            templatesdb.Value.Rollback() |> ignore
+            Database.Value.Rollback() |> ignore
             return false
         | None -> return false
       }
 
     static member Delete(searchKind) =
-      match Templates.FindOne(searchKind) with
+      match Templates.FindOne(searchKind: TemplateSearchKind) with
       | Some template ->
         FileSystem.RemoveTemplateDirectory(template.path)
 
-        repositories.Value.Delete(template._id)
+        // remove the quick template access
+        TemplatesCol.Value.DeleteMany(fun template ->
+          template.parent = template._id)
+        |> ignore
+
+        RepositoriesCol.Value.Delete(template._id)
       | None -> false

--- a/src/Perla/Scaffolding.fsi
+++ b/src/Perla/Scaffolding.fsi
@@ -33,7 +33,7 @@ module Scaffolding =
           author: string
           license: string
           repositoryUrl: string
-          group: string
+          group: string<RepositoryGroup>
           templates: TemplateConfigurationItem seq
           createdAt: DateTime
           updatedAt: Nullable<DateTime> }
@@ -47,7 +47,7 @@ module Scaffolding =
         { _id: ObjectId
           parent: ObjectId
           name: string
-          group: string
+          group: string<TemplateGroup>
           shortName: string
           description: string option
           fullPath: string<SystemPath> }
@@ -56,7 +56,7 @@ module Scaffolding =
     type QuickAccessSearch =
         | Id of ObjectId
         | Name of string
-        | Group of string
+        | Group of string<TemplateGroup>
         | ShortName of string
         | Parent of ObjectId
 
@@ -64,9 +64,16 @@ module Scaffolding =
     [<RequireQualifiedAccess>]
     type TemplateSearchKind =
         | Id of ObjectId
+        | Group of group: string<RepositoryGroup>
         | Username of name: string
         | Repository of repository: string
         | FullName of username: string * repository: string
+
+    [<RequireQualifiedAccess; Struct>]
+    type TemplateScriptKind =
+        | Template of template: TemplateItem
+        | Repository of repository: PerlaTemplateRepository
+
 
     [<Class>]
     type Templates =
@@ -79,14 +86,9 @@ module Scaffolding =
         /// exists
         /// </summary>
         /// <param name="name">Full name of the template in the Username/Repository scheme</param>
-        static member Exists: name: TemplateSearchKind -> bool
-        /// <summary>
-        /// Checks if the the repository with given a name in the form of
-        /// Username/Repository
-        /// exists
-        /// </summary>
-        /// <param name="name">Full name of the template in the Username/Repository scheme</param>
         static member FindOne: name: TemplateSearchKind -> PerlaTemplateRepository option
         static member FindTemplateItems: searchParams: QuickAccessSearch -> TemplateItem list
         static member Update: template: PerlaTemplateRepository -> Task<Result<bool, string>>
         static member Delete: searchKind: TemplateSearchKind -> bool
+
+        static member GetTemplateScriptContent: scriptKind: TemplateScriptKind -> obj option

--- a/src/Perla/Scaffolding.fsi
+++ b/src/Perla/Scaffolding.fsi
@@ -15,18 +15,51 @@ module Scaffolding =
     val getConfigurationFromScript: content: string -> obj option
 
     [<CLIMutable>]
+    type TemplateConfigurationItem =
+        { childId: ObjectId
+          name: string
+          shortName: string
+          description: string }
+
+    [<CLIMutable>]
     type PerlaTemplateRepository =
         { _id: ObjectId
           username: string
           repository: string
           branch: string
           path: string<SystemPath>
+          name: string
+          description: string
+          author: string
+          license: string
+          repositoryUrl: string
+          group: string
+          templates: TemplateConfigurationItem seq
           createdAt: DateTime
           updatedAt: Nullable<DateTime> }
 
         member ToFullName: string
         member ToFullNameWithBranch: string
         static member DefaultTemplatesRepository: string * string * string
+
+    [<CLIMutable>]
+    type TemplateItem =
+        { _id: ObjectId
+          parent: ObjectId
+          name: string
+          group: string
+          shortName: string
+          description: string option
+          fullPath: string<SystemPath> }
+
+    [<RequireQualifiedAccess>]
+    type QuickAccessSearch =
+        | Id of ObjectId
+        | Name of string
+        | Group of string
+        | ShortName of string
+        | Parent of ObjectId
+
 
     [<RequireQualifiedAccess>]
     type TemplateSearchKind =
@@ -37,8 +70,9 @@ module Scaffolding =
 
     [<Class>]
     type Templates =
-        static member List: unit -> PerlaTemplateRepository list
-        static member Add: user: string * repository: string * branch: string -> Task<ObjectId>
+        static member ListRepositories: unit -> PerlaTemplateRepository list
+        static member ListTemplateItems: unit -> TemplateItem list
+        static member Add: user: string * repository: string * branch: string -> Task<Result<ObjectId, string>>
         /// <summary>
         /// Checks if the the repository with given a name in the form of
         /// Username/Repository
@@ -53,5 +87,6 @@ module Scaffolding =
         /// </summary>
         /// <param name="name">Full name of the template in the Username/Repository scheme</param>
         static member FindOne: name: TemplateSearchKind -> PerlaTemplateRepository option
-        static member Update: template: PerlaTemplateRepository -> Task<bool>
+        static member FindTemplateItems: searchParams: QuickAccessSearch -> TemplateItem list
+        static member Update: template: PerlaTemplateRepository -> Task<Result<bool, string>>
         static member Delete: searchKind: TemplateSearchKind -> bool

--- a/src/Perla/Types.fs
+++ b/src/Perla/Types.fs
@@ -19,6 +19,13 @@ module Units =
   [<Measure>]
   type UserPath
 
+  [<Measure>]
+  type RepositoryGroup
+
+  [<Measure>]
+  type TemplateGroup
+
+
 
 module Types =
   open FSharp.UMX

--- a/src/Perla/Types.fsi
+++ b/src/Perla/Types.fsi
@@ -18,6 +18,13 @@ module Units =
     [<Measure>]
     type UserPath
 
+    [<Measure>]
+    type RepositoryGroup
+
+    [<Measure>]
+    type TemplateGroup
+
+
 module Types =
     open FSharp.UMX
     open Units

--- a/tests/Perla.Tests/CommandOptions.fs
+++ b/tests/Perla.Tests/CommandOptions.fs
@@ -1,0 +1,101 @@
+﻿namespace Perla.Tests
+
+open Xunit
+open System
+open System.CommandLine
+open FSharp.SystemCommandLine.Inputs
+open System.CommandLine.Parsing
+open System.CommandLine.Invocation
+open System.CommandLine.Builder
+
+open FsToolkit.ErrorHandling
+
+open Perla
+open Perla.Commands
+
+[<AutoOpen>]
+module Extensions =
+
+  type HandlerInput<'a> with
+
+    member this.GetArgument<'T>() : Argument<'T> option =
+      match this.Source with
+      | ParsedArgument a -> a :?> Argument<'T> |> Some
+      | _ -> None
+
+    member this.GetOption<'T>() : Option<'T> option =
+      match this.Source with
+      | ParsedOption o -> o :?> Option<'T> |> Some
+      | _ -> None
+
+    member this.GetValue(ctx: ParseResult) : 'T option =
+      match this.Source with
+      | ParsedOption o ->
+        o :?> Option<'T> |> ctx.GetValueForOption |> Option.ofNull
+      | ParsedArgument a ->
+        a :?> Argument<'T> |> ctx.GetValueForArgument |> Option.ofNull
+      | Context -> None
+
+
+module CommandOptions =
+
+  let GetRootCommand (handler: Command, command: string) =
+    let root = RootCommand()
+    root.AddCommand(handler)
+    root.Parse(command)
+
+  [<Fact>]
+  let ``Commands.Setup can parse options`` () =
+    let result =
+      GetRootCommand(Commands.Setup, "setup -y --skip-playwright false")
+
+    let skipPlaywright: bool option =
+      SetupInputs.skipPlaywright.GetValue result |> Option.flatten
+
+    let skipPrompts: bool option =
+      SetupInputs.skipPrompts.GetValue result |> Option.flatten
+
+    Assert.Empty(result.Errors)
+    Assert.True(skipPrompts |> Option.defaultValue false)
+    Assert.False(skipPlaywright |> Option.defaultValue true)
+
+  [<Fact>]
+  let ``Parse Commands.Setup without options should not fail`` () =
+    let result = GetRootCommand(Commands.Setup, "setup")
+
+    let skipPlaywright: bool option =
+      SetupInputs.skipPlaywright.GetValue result |> Option.flatten
+
+    let skipPrompts: bool option =
+      SetupInputs.skipPrompts.GetValue result |> Option.flatten
+
+    Assert.Empty(result.Errors)
+    Assert.True(skipPrompts |> Option.isNone)
+    Assert.True(skipPlaywright |> Option.isNone)
+
+  [<Fact>]
+  let ``Commands.Build can parse options`` () =
+    let result =
+      GetRootCommand(
+        Commands.Build,
+        "build --dev -epl false -rim --preview false"
+      )
+
+    let asDev: bool option =
+      SharedInputs.asDev.GetValue result |> Option.flatten
+
+    let enablePreloads: bool option =
+      BuildInputs.enablePreloads.GetValue result |> Option.flatten
+
+    let rebuildImportMap: bool option =
+      BuildInputs.rebuildImportMap.GetValue result |> Option.flatten
+
+    let preview: bool option =
+      BuildInputs.preview.GetValue result |> Option.flatten
+
+
+    Assert.Empty(result.Errors)
+    Assert.True(asDev.Value)
+    Assert.False(enablePreloads.Value)
+    Assert.True(rebuildImportMap.Value)
+    Assert.False(preview.Value)

--- a/tests/Perla.Tests/Dependencies.fs
+++ b/tests/Perla.Tests/Dependencies.fs
@@ -45,11 +45,11 @@ module Dependencies =
     with
     | Some url ->
       match ExtractDependencyInfoFromUrl url with
-      | Some (resultProvider, name, version) ->
+      | ValueSome(resultProvider, name, version) ->
         Assert.Equal(provider, resultProvider)
         Assert.Equal(LodashName, name)
         Assert.Equal(LodashVersion, version)
-      | None ->
+      | ValueNone ->
         Assert.Fail(
           $"Failed to extract Dependency information from URL, its structure may have changed: {url}"
         )
@@ -62,11 +62,11 @@ module Dependencies =
     with
     | Some url ->
       match ExtractDependencyInfoFromUrl url with
-      | Some (resultProvider, name, version) ->
+      | ValueSome(resultProvider, name, version) ->
         Assert.Equal(provider, resultProvider)
         Assert.Equal(LitName, name)
         Assert.Equal(LitVersion, version)
-      | None ->
+      | ValueNone ->
         Assert.Fail(
           $"Failed to extract Dependency information from URL, its structure may have changed: {url}"
         )
@@ -79,11 +79,11 @@ module Dependencies =
     with
     | Some url ->
       match ExtractDependencyInfoFromUrl url with
-      | Some (resultProvider, name, version) ->
+      | ValueSome(resultProvider, name, version) ->
         Assert.Equal(provider, resultProvider)
         Assert.Equal("jquery", name)
         Assert.Equal("3.6.1", version)
-      | None ->
+      | ValueNone ->
         Assert.Fail(
           $"Failed to extract Dependency information from URL, its structure may have changed: {url}"
         )
@@ -265,7 +265,7 @@ module Dependencies =
     )
 
     Assert.Empty(devDependencies)
-    
+
   [<Fact>]
   let ``LocateDependenciesFromMapAndConfig should grab dependencies from import map if they exist in the configuration``
     ()
@@ -287,11 +287,11 @@ module Dependencies =
                 alias = None }
               { name = LodashName
                 version = Some LodashVersion
-                alias = None }]
+                alias = None } ]
           devDependencies =
             [ { name = "jquery"
                 version = Some "3.6.1"
-                alias = None }]}
+                alias = None } ] }
 
     let dependencies, devDependencies =
       Dependencies.LocateDependenciesFromMapAndConfig(importMap, config)
@@ -323,4 +323,3 @@ module Dependencies =
         alias = None },
       dependencies
     )
-

--- a/tests/Perla.Tests/Perla.Tests.fsproj
+++ b/tests/Perla.Tests/Perla.Tests.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="Dependencies.fs" />
     <Compile Include="Configuration.fs" />
     <Compile Include="TypesAndOptions.fs" />
+    <Compile Include="CommandOptions.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Perla.Tests/paket.references
+++ b/tests/Perla.Tests/paket.references
@@ -4,6 +4,7 @@ Thoth.Json.Net
 FsToolkit.ErrorHandling.TaskResult
 CliWrap
 Flurl.Http
+System.CommandLine
 
 group Tests
 Microsoft.NET.Test.Sdk


### PR DESCRIPTION
This PR addresses some of the issues found in #103, #95 and #102

It is mainly aimed to enrich template related operations from creating new projects to add and show information related to existing template in perla.

This also will help to improve the workflow related to create new projects e.g.

```
perla new sample --template-name AngelMunoz/perla-templates/fable-feliz
```

```
perla new sample -id perla.templates.fable.feliz
perla new sample -t ff
```
where -id is an android-like that should be a unique identifier for each template in a repository and `ff` is a short name defined in the template's configuration

These changes require a little bit more of work on the template authoring experience (writing a json file) but I think it is worth it.


Also as a new option, using perla new without flags features a wizard-like experience where it will show you the existing templates in the system and which one you can pick up, it will also share with you the short command syntax for the next time you create a project 

```
perla new sample
```


https://user-images.githubusercontent.com/8684875/231566225-57bebad3-3ad3-4eed-8295-fedbe3cbf05a.mp4



Lastly we've refactored a bit the contents of the Commands and separated handlers from inputs and commands themselves so we can start testing that our inputs get parsed as we intend them to use
e.g. being able to parse `add package -s esm.sh` and ensure we can use `-s esm.sh` or `-s unpkg` or any other alternatives we support
