### PR TITLE
custom paths

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,6 +45,37 @@
             "console": "integratedTerminal"
         },
         {
+            "name": "Perla resolution",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/Perla/bin/Debug/net7.0/Perla.dll",
+            "args": [
+                "resolution",
+                "@app/components",
+                "./components/exports.js"
+            ],
+            "cwd": "${workspaceFolder}/sample",
+            "stopAtEntry": false,
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "Perla add nested",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/Perla/bin/Debug/net7.0/Perla.dll",
+            "args": [
+                "add",
+                "lodash/fp/object",
+                "-s",
+                "unpkg"
+            ],
+            "cwd": "${workspaceFolder}/sample",
+            "stopAtEntry": false,
+            "console": "integratedTerminal"
+        },
+        {
             "name": "Perla test watch",
             "type": "coreclr",
             "request": "launch",

--- a/src/Perla/Build.fs
+++ b/src/Perla/Build.fs
@@ -113,6 +113,7 @@ type Build =
           yield! config.dependencies
           yield! config.devDependencies
         ]
+
     seq {
       for dependency in dependencies do
         dependency.name
@@ -207,13 +208,14 @@ type Build =
 
         lfsGlob |> Seq.toArray |> Array.Parallel.iter copyLocal)
 
-  static member EmitEnvFile(config: PerlaConfig) =
+  static member EmitEnvFile(config: PerlaConfig, ?tmpPath: string<SystemPath>) =
+    let tmpPath = defaultArg tmpPath config.build.outDir |> UMX.untag
+
     match Env.GetEnvContent() with
     | Some content ->
       // remove the leading slash
       let targetFile = (UMX.untag config.envPath)[1..]
 
-      let path = Path.Combine(UMX.untag config.build.outDir, targetFile)
-
+      let path = Path.Combine(tmpPath, targetFile) |> Path.GetFullPath
       File.WriteAllText(path, content)
     | None -> ()

--- a/src/Perla/Build.fs
+++ b/src/Perla/Build.fs
@@ -113,7 +113,6 @@ type Build =
           yield! config.dependencies
           yield! config.devDependencies
         ]
-
     seq {
       for dependency in dependencies do
         dependency.name
@@ -123,6 +122,7 @@ type Build =
 
       if config.enableEnv && config.build.emitEnvFile then
         UMX.untag config.envPath
+        Constants.EnvBareImport
 
       yield! config.esbuild.externals
     }

--- a/src/Perla/Build.fsi
+++ b/src/Perla/Build.fsi
@@ -29,4 +29,5 @@ type Build =
   static member CopyGlobs:
     config: BuildConfig * tempDir: string<SystemPath> -> unit
 
-  static member EmitEnvFile: config: PerlaConfig -> unit
+  static member EmitEnvFile:
+    config: PerlaConfig * ?tmpPath: string<SystemPath> -> unit

--- a/src/Perla/Commands.fsi
+++ b/src/Perla/Commands.fsi
@@ -19,6 +19,9 @@ type PerlaOptions =
 type PerlaArguments =
   static member Properties: Argument<string array>
 
+  static member ArgStringMaybe:
+    name: string * ?description: string -> Argument<string option>
+
 [<RequireQualifiedAccess>]
 module SharedInputs =
   val asDev: HandlerInput<bool option>
@@ -48,6 +51,11 @@ module PackageInputs =
   val version: HandlerInput<string option>
   val currentPage: HandlerInput<int option>
   val showAsNpm: HandlerInput<bool option>
+
+  val import: HandlerInput<string>
+  val resolution: HandlerInput<string option>
+  val addOrUpdate: HandlerInput<bool option>
+  val remove: HandlerInput<bool option>
 
 [<RequireQualifiedAccess>]
 module TemplateInputs =
@@ -92,6 +100,7 @@ module Commands =
   val SearchPackage: Command
   val ShowPackage: Command
   val AddPackage: Command
+  val AddResolution: Command
   val RemovePackage: Command
   val ListPackages: Command
   val RestoreImportMap: Command

--- a/src/Perla/Commands.fsi
+++ b/src/Perla/Commands.fsi
@@ -55,7 +55,7 @@ module PackageInputs =
   val import: HandlerInput<string>
   val resolution: HandlerInput<string option>
   val addOrUpdate: HandlerInput<bool option>
-  val remove: HandlerInput<bool option>
+  val removeResolution: HandlerInput<bool>
 
 [<RequireQualifiedAccess>]
 module TemplateInputs =

--- a/src/Perla/Configuration.fsi
+++ b/src/Perla/Configuration.fsi
@@ -39,6 +39,7 @@ module Types =
     | Dependencies of Dependency seq
     | DevDependencies of Dependency seq
     | Fable of FableField seq
+    | Paths of Map<string<BareImport>, string<ResolutionUrl>>
 
 open Types
 
@@ -52,18 +53,37 @@ module Defaults =
   val TestConfig: TestConfig
   val PerlaConfig: PerlaConfig
 
-val internal fromEnv: config: PerlaConfig -> PerlaConfig
+module internal ConfigExtraction =
 
-val internal fromCli:
-  runConfig: RunConfiguration option ->
-  provider: Provider option ->
-  serverOptions: DevServerField seq option ->
-  testingOptions: TestingField seq option ->
-  config: PerlaConfig ->
-    PerlaConfig
+  [<RequireQualifiedAccess>]
+  module FromDecoders =
+    open Json.ConfigDecoders
 
-val internal fromFile:
-  fileContent: JsonObject option -> config: PerlaConfig -> PerlaConfig
+    val GetFable: FableConfig option * DecodedFableConfig option -> FableConfig option
+    val GetDevServer: DevServerConfig * DecodedDevServer option -> DevServerConfig option
+    val GetBuild: BuildConfig * DecodedBuild option -> BuildConfig option
+    val GetEsbuild: EsbuildConfig * DecodedEsbuild option -> EsbuildConfig option
+    val GetTesting: TestConfig * DecodedTesting option -> TestConfig option
+
+  [<RequireQualifiedAccess>]
+  module FromFields =
+    val GetServerFields: DevServerConfig * DevServerField seq option -> DevServerField seq
+    val GetMinify: RunConfiguration * DevServerField seq -> bool
+    val GetDevServerOptions: DevServerConfig * DevServerField seq -> DevServerConfig
+    val GetTesting: TestConfig * TestingField seq option -> TestConfig
+
+  val FromEnv: config: PerlaConfig -> PerlaConfig
+
+  val FromCli:
+    runConfig: RunConfiguration option ->
+    provider: Provider option ->
+    serverOptions: DevServerField seq option ->
+    testingOptions: TestingField seq option ->
+    config: PerlaConfig ->
+      PerlaConfig
+
+  val FromFile:
+    fileContent: JsonObject option -> config: PerlaConfig -> PerlaConfig
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module internal Json =

--- a/src/Perla/Constants.fs
+++ b/src/Perla/Constants.fs
@@ -28,7 +28,7 @@ let FableProject = "./src/App.fsproj"
 let EnvPath = "/env.js"
 
 [<Literal>]
-let EnvBareImport = "__app/env"
+let EnvBareImport = "@@perla/env"
 
 [<Literal>]
 let ProxyConfigName = "proxy-config.json"

--- a/src/Perla/Constants.fs
+++ b/src/Perla/Constants.fs
@@ -28,6 +28,9 @@ let FableProject = "./src/App.fsproj"
 let EnvPath = "/env.js"
 
 [<Literal>]
+let EnvBareImport = "__app/env"
+
+[<Literal>]
 let ProxyConfigName = "proxy-config.json"
 
 [<Literal>]

--- a/src/Perla/Constants.fsi
+++ b/src/Perla/Constants.fsi
@@ -25,6 +25,9 @@ val FableProject: string = "./src/App.fsproj"
 val EnvPath: string = "/env.js"
 
 [<Literal>]
+val EnvBareImport: string = "__app/env"
+
+[<Literal>]
 val ProxyConfigName: string = "proxy-config.json"
 
 [<Literal>]

--- a/src/Perla/Constants.fsi
+++ b/src/Perla/Constants.fsi
@@ -25,7 +25,7 @@ val FableProject: string = "./src/App.fsproj"
 val EnvPath: string = "/env.js"
 
 [<Literal>]
-val EnvBareImport: string = "__app/env"
+val EnvBareImport: string = "@@perla/env"
 
 [<Literal>]
 val ProxyConfigName: string = "proxy-config.json"

--- a/src/Perla/Esbuild.fsi
+++ b/src/Perla/Esbuild.fsi
@@ -1,6 +1,5 @@
 ﻿namespace Perla.Esbuild
 
-open System.IO
 open System.Text
 open System.Runtime.InteropServices
 open CliWrap
@@ -19,17 +18,27 @@ type LoaderType =
 
 [<Class>]
 type Esbuild =
+  /// Uses esbuild's build API
+  /// This is the most flexible option and allows for simpler customization
+  /// This should be performed only when the file system is available
   static member ProcessJS:
+    workingDirectory: string *
     entryPoint: string *
     config: EsbuildConfig *
-    outDir: string<SystemPath> *
-    [<Optional>] ?externals: seq<string> ->
+    outDir: string *
+    [<Optional>] ?externals: string seq *
+    [<Optional>] ?aliases: Map<string<BareImport>, string<ResolutionUrl>> ->
       Command
 
   static member ProcessCss:
-    entryPoint: string * config: EsbuildConfig * outDir: string<SystemPath> ->
+    workingDirectory: string *
+    entryPoint: string *
+    config: EsbuildConfig *
+    outDir: string ->
       Command
 
+  /// Uses esbuild's transform API via stdin/stdout
+  /// This means each file will be processed in isolation
   static member BuildSingleFile:
     config: EsbuildConfig *
     content: string *

--- a/src/Perla/Handlers.fsi
+++ b/src/Perla/Handlers.fsi
@@ -3,6 +3,9 @@
 open System.Threading
 open System.Threading.Tasks
 
+open FSharp.UMX
+
+open Perla.Units
 open Perla.Types
 open Perla.PackageManager.Types
 
@@ -89,6 +92,15 @@ type DescribeOptions = {
   current: bool
 }
 
+[<Struct>]
+type PathOperation =
+  | AddOrUpdate of addImport: string<BareImport> * addPath: string<ResolutionUrl>
+  | Remove of removeImport: string
+
+type PathsOptions = {
+  operation: PathOperation
+}
+
 module Handlers =
 
   val runSetup:
@@ -116,6 +128,8 @@ module Handlers =
   val runShowPackage:
     options: ShowPackageOptions * cancellationToken: CancellationToken ->
       Task<int>
+
+  val runAddResolution: options: PathsOptions -> Task<int>
 
   val runAddPackage:
     options: AddPackageOptions * cancellationToken: CancellationToken ->

--- a/src/Perla/Json.fsi
+++ b/src/Perla/Json.fsi
@@ -97,6 +97,7 @@ module ConfigDecoders =
     mountDirectories: Map<string<ServerUrl>, string<UserPath>> option
     enableEnv: bool option
     envPath: string<ServerUrl> option
+    paths: Map<string<BareImport>, string<ResolutionUrl>> option
     dependencies: Dependency seq option
     devDependencies: Dependency seq option
   }

--- a/src/Perla/Library.fsi
+++ b/src/Perla/Library.fsi
@@ -4,11 +4,13 @@ open System.Text.RegularExpressions
 
 open Spectre.Console
 open Spectre.Console.Rendering
+open FSharp.UMX
+open Perla.Units
+open Perla.Types
+open Perla.PackageManager.Types
 
 [<AutoOpen>]
 module Lib =
-  open Perla.Types
-  open Perla.PackageManager.Types
 
   [<return: Struct>]
   val internal (|ParseRegex|_|):
@@ -67,3 +69,13 @@ module Lib =
     member Item: string -> IRenderable option with get
     member Item: (string * string) -> IRenderable option with get
     member Item: (string * string * string) -> IRenderable option with get
+
+  type ImportMap with
+
+    member RemoveResolutions:
+      resolutions: Map<string<BareImport>, string<ResolutionUrl>> -> ImportMap
+
+    member AddResolutions:
+      resolutions: Map<string<BareImport>, string<ResolutionUrl>> -> ImportMap
+
+    member AddEnvResolution: config: PerlaConfig -> ImportMap

--- a/src/Perla/Program.fs
+++ b/src/Perla/Program.fs
@@ -138,6 +138,7 @@ let main argv =
       Commands.SearchPackage
       Commands.ShowPackage
       Commands.AddPackage
+      Commands.AddResolution
       Commands.RemovePackage
       Commands.ListPackages
       Commands.RestoreImportMap

--- a/src/Perla/Server.fs
+++ b/src/Perla/Server.fs
@@ -244,7 +244,6 @@ module LiveReload =
     Logger.log ($"Compilation Error: {err.Substring(0, 80)}...", target = Serve)
     response.WriteAsync(ReloadEvents.CompileError(err).AsString)
 
-
 [<RequireQualifiedAccess>]
 module Middleware =
 
@@ -256,7 +255,7 @@ module Middleware =
 
   let processFile
     (
-      setContentAndWrite: string * (byte array) -> Task<_>,
+      setContentAndWrite: string * byte array -> Task<_>,
       reqPath: string,
       mimeType: string,
       requestedAs: RequestedAs,
@@ -272,14 +271,14 @@ document.head.appendChild(style).innerHTML=String.raw`{content}`;"""
     | "application/json", RequestedAs.JS ->
       setContentAndWrite (
         MimeTypeNames.DefaultJavaScript,
-        (processJsonAsJs (System.Text.Encoding.UTF8.GetString(content))
-         |> System.Text.Encoding.UTF8.GetBytes)
+        (processJsonAsJs (Encoding.UTF8.GetString(content))
+         |> Encoding.UTF8.GetBytes)
       )
     | "text/css", Normal ->
       setContentAndWrite (
         MimeTypeNames.DefaultJavaScript,
-        (processCssAsJs (System.Text.Encoding.UTF8.GetString(content), reqPath)
-         |> System.Text.Encoding.UTF8.GetBytes)
+        (processCssAsJs (Encoding.UTF8.GetString(content), reqPath)
+         |> Encoding.UTF8.GetBytes)
       )
     | mimeType, ModuleAssertion
     | mimeType, Normal -> setContentAndWrite (mimeType, content)
@@ -338,7 +337,7 @@ document.head.appendChild(style).innerHTML=String.raw`{content}`;"""
       Json.TestEventFromJson toDecode
       |> Result.teeError (fun err ->
         Logger.log $"[bold red]{err.EscapeMarkup()}[/]")
-      |> Result.iter (testEvents.OnNext)
+      |> Result.iter testEvents.OnNext
 
       return Results.Ok()
     }
@@ -438,7 +437,7 @@ document.head.appendChild(style).innerHTML=String.raw`{content}`;"""
 
   let IndexHandler (config: PerlaConfig) (_: HttpContext) =
     let content = FileSystem.IndexFile(config.index)
-    let map = FileSystem.GetImportMap()
+    let map = FileSystem.GetImportMap().AddEnvResolution(config)
 
     use context = BrowsingContext.New(Configuration.Default)
 

--- a/src/Perla/Types.fs
+++ b/src/Perla/Types.fs
@@ -25,7 +25,11 @@ module Units =
   [<Measure>]
   type TemplateGroup
 
+  [<Measure>]
+  type BareImport
 
+  [<Measure>]
+  type ResolutionUrl
 
 module Types =
   open FSharp.UMX
@@ -121,6 +125,7 @@ module Types =
     mountDirectories: Map<string<ServerUrl>, string<UserPath>>
     enableEnv: bool
     envPath: string<ServerUrl>
+    paths: Map<string<BareImport>, string<ResolutionUrl>>
     dependencies: Dependency seq
     devDependencies: Dependency seq
   }

--- a/src/Perla/Types.fsi
+++ b/src/Perla/Types.fsi
@@ -24,6 +24,13 @@ module Units =
   [<Measure>]
   type TemplateGroup
 
+  [<Measure>]
+  type BareImport
+
+  [<Measure>]
+  type ResolutionUrl
+
+
 
 module Types =
   open FSharp.UMX
@@ -121,6 +128,7 @@ module Types =
     mountDirectories: Map<string<ServerUrl>, string<UserPath>>
     enableEnv: bool
     envPath: string<ServerUrl>
+    paths: Map<string<BareImport>, string<ResolutionUrl>>
     dependencies: Dependency seq
     devDependencies: Dependency seq
   }

--- a/tests/Perla.Tests/Configuration.fs
+++ b/tests/Perla.Tests/Configuration.fs
@@ -1,21 +1,605 @@
 namespace Perla.Tests
 
+open System.Collections.Generic
+
+open Perla.Configuration.Types
 open Xunit
+open FSharp.UMX
 
 open Perla
 open Perla.Types
-open Perla.Logger
+open Perla.Json.ConfigDecoders
 open Perla.Configuration
 
 open FsToolkit.ErrorHandling
 
+
 module Configuration =
+  module FromDecoders =
+    open ConfigExtraction
+
+    [<Fact>]
+    let ``FromDecoders.GetFable returns None if DecodedFableConfig is not present``
+      ()
+      =
+      let result = FromDecoders.GetFable(None, None)
+      Assert.True(result.IsNone)
+
+    [<Fact>]
+    let ``FromDecoders.GetFable returns Some if DecodedFableConfig is present``
+      ()
+      =
+      let decoded: DecodedFableConfig = {
+        extension = None
+        project = None
+        outDir = None
+        sourceMaps = None
+      }
+
+      let result = FromDecoders.GetFable(None, Some decoded)
+      Assert.True(result.IsSome)
+
+      match result with
+      | Some {
+               extension = extension
+               project = project
+               outDir = outDir
+               sourceMaps = sourceMaps
+             } ->
+        Assert.Equal(
+          UMX.untag Defaults.FableConfig.extension,
+          UMX.untag extension
+        )
+
+        Assert.Equal(UMX.untag Defaults.FableConfig.project, UMX.untag project)
+        Assert.True(outDir.IsNone)
+        Assert.Equal(Defaults.FableConfig.sourceMaps, sourceMaps)
+      | None -> Assert.Fail "Should not be None"
+
+    [<Fact>]
+    let ``FromDecoders.GetFable returns respects existing config`` () =
+      let expectedProject = "./fsharp/App.fsproj"
+      let expectedOutDir = "./src/js"
+      let expectedExtension = ".js"
+
+      let defaults = {
+        Defaults.FableConfig with
+            project = UMX.tag expectedProject
+            outDir = Some(UMX.tag expectedOutDir)
+      }
+
+      let decoded: DecodedFableConfig = {
+        extension = Some(UMX.tag expectedExtension)
+        project = None
+        outDir = None
+        sourceMaps = None
+      }
+
+      let result = FromDecoders.GetFable(Some defaults, Some decoded)
+      Assert.True(result.IsSome)
+
+      match result with
+      | Some {
+               extension = extension
+               project = project
+               outDir = outDir
+               sourceMaps = sourceMaps
+             } ->
+        Assert.Equal(expectedExtension, UMX.untag extension)
+
+        Assert.Equal(expectedProject, UMX.untag project)
+
+        match outDir with
+        | Some outDir -> Assert.Equal(expectedOutDir, UMX.untag outDir)
+        | None -> Assert.Fail "outDir should be present"
+
+        Assert.Equal(Defaults.FableConfig.sourceMaps, sourceMaps)
+      | None -> Assert.Fail "Fable Config should be present"
+
+    [<Fact>]
+    let ``FromDecoders.GetDevServer returns None if no DecodedDevServer is present``
+      ()
+      =
+      let config = Defaults.DevServerConfig
+      let result = FromDecoders.GetDevServer(config, None)
+      Assert.True(result.IsNone)
+
+    [<Fact>]
+    let ``FromDecoders.GetDevServer returns DecodedDevServer`` () =
+      let config = Defaults.DevServerConfig
+
+      let decoded: DecodedDevServer = {
+        port = None
+        host = None
+        liveReload = None
+        useSSL = None
+        proxy = None
+      }
+
+      let result = FromDecoders.GetDevServer(config, Some decoded)
+
+      match result with
+      | Some {
+               port = port
+               host = host
+               liveReload = liveReload
+               useSSL = useSSL
+               proxy = proxy
+             } ->
+        Assert.Equal(config.port, port)
+        Assert.Equal(config.host, host)
+        Assert.Equal(config.liveReload, liveReload)
+        Assert.Equal(config.useSSL, useSSL)
+        Assert.True(Map.isEmpty proxy)
+      | None -> Assert.Fail "DevServer config should be present"
+
+    [<Fact>]
+    let ``FromDecoders.GetDevServer respects existing config`` () =
+      let expectedPort = 4000
+      let expectedHost = "0.0.0.0"
+      let expectedUseSSL = false
+
+      let config = {
+        Defaults.DevServerConfig with
+            port = 8080
+            useSSL = expectedUseSSL
+      }
+
+      let decoded: DecodedDevServer = {
+        port = Some expectedPort
+        host = Some expectedHost
+        liveReload = None
+        useSSL = None
+        proxy = None
+      }
+
+      let result = FromDecoders.GetDevServer(config, Some decoded)
+
+      match result with
+      | Some {
+               port = port
+               host = host
+               liveReload = liveReload
+               useSSL = useSSL
+               proxy = proxy
+             } ->
+        Assert.Equal(expectedPort, port)
+        Assert.Equal(expectedHost, host)
+        Assert.Equal(expectedUseSSL, useSSL)
+        Assert.Equal(config.liveReload, liveReload)
+        Assert.True(Map.isEmpty proxy)
+      | None -> Assert.Fail "DevServer config should be present"
+
+    [<Fact>]
+    let ``FromDecoders.GetBuild returns None if no DecodedBuild is present``
+      ()
+      =
+      let config = Defaults.BuildConfig
+      let result = FromDecoders.GetBuild(config, None)
+      Assert.True(result.IsNone)
+
+
+    [<Fact>]
+    let ``FromDecoders.GetBuild returns DecodedBuild`` () =
+      let config = Defaults.BuildConfig
+
+      let decoded: DecodedBuild = {
+        excludes = None
+        includes = None
+        outDir = None
+        emitEnvFile = None
+      }
+
+      let result = FromDecoders.GetBuild(config, Some decoded)
+
+      match result with
+      | Some {
+               excludes = excludes
+               includes = includes
+               outDir = outDir
+               emitEnvFile = emitEnvFile
+             } ->
+        Assert.Empty(includes)
+
+        for expectedExclude in config.excludes do
+          Assert.Contains(expectedExclude, excludes)
+
+        Assert.Equal(UMX.untag config.outDir, UMX.untag outDir)
+
+        Assert.Equal(config.emitEnvFile, emitEnvFile)
+      | None -> Assert.Fail "Build config should be present"
+
+    [<Fact>]
+    let ``FromDecoders.GetBuild respects existing values`` () =
+
+      let expectedOutDir = "./bin/dist"
+      let expectedEmitEnvFile = false
+      let expectedInclude = "vfs:**/*.html"
+
+      let config = {
+        Defaults.BuildConfig with
+            includes = [ expectedInclude ]
+            emitEnvFile = expectedEmitEnvFile
+      }
+
+      let decoded: DecodedBuild = {
+        excludes = None
+        includes = None
+        outDir = Some(UMX.tag expectedOutDir)
+        emitEnvFile = None
+      }
+
+      let result = FromDecoders.GetBuild(config, Some decoded)
+
+      match result with
+      | Some {
+               excludes = excludes
+               includes = includes
+               outDir = outDir
+               emitEnvFile = emitEnvFile
+             } ->
+        Assert.Contains(expectedInclude, includes)
+
+        for expectedExclude in config.excludes do
+          Assert.Contains(expectedExclude, excludes)
+
+        Assert.Equal(expectedOutDir, UMX.untag outDir)
+        Assert.Equal(expectedEmitEnvFile, emitEnvFile)
+      | None -> Assert.Fail "DevServer config should be present"
+
+
+    [<Fact>]
+    let ``FromDecoders.GetEsbuild returns None if no DecodedBuild is present``
+      ()
+      =
+      let config = Defaults.EsbuildConfig
+      let result = FromDecoders.GetEsbuild(config, None)
+      Assert.True(result.IsNone)
+
+
+    [<Fact>]
+    let ``FromDecoders.GetEsbuild returns DecodedBuild`` () =
+      let config = Defaults.EsbuildConfig
+
+      let decoded: DecodedEsbuild = {
+        externals = None
+        injects = None
+        minify = None
+        version = None
+        ecmaVersion = None
+        fileLoaders = None
+        jsxAutomatic = None
+        esBuildPath = None
+        jsxImportSource = None
+      }
+
+      let result = FromDecoders.GetEsbuild(config, Some decoded)
+
+      match result with
+      | Some {
+               externals = externals
+               injects = injects
+               minify = minify
+               version = version
+               ecmaVersion = ecmaVersion
+               fileLoaders = fileLoaders
+               jsxAutomatic = jsxAutomatic
+               esBuildPath = esBuildPath
+               jsxImportSource = jsxImportSource
+             } ->
+        Assert.Empty(externals)
+        Assert.Empty(injects)
+        Assert.Equal(config.minify, minify)
+        Assert.Equal(config.ecmaVersion, ecmaVersion)
+        Assert.Equal(UMX.untag config.esBuildPath, UMX.untag esBuildPath)
+        Assert.Equal(UMX.untag config.version, UMX.untag version)
+        Assert.Equal(config.jsxImportSource, jsxImportSource)
+        Assert.Equal(config.jsxAutomatic, jsxAutomatic)
+        let loaders = fileLoaders :> IDictionary<string, string>
+
+        for KeyValue(expectedKey, expectedValue) in config.fileLoaders do
+          let value = Assert.Contains(expectedKey, loaders)
+          Assert.Equal(expectedValue, value)
+
+      | None -> Assert.Fail "Build config should be present"
+
+    [<Fact>]
+    let ``FromDecoders.GetEsbuild respects existing values`` () =
+      let expectedVersion = "0.0.0"
+      let expectedEcmaVersion = "ES2022"
+      let expectedMinify = false
+      let expectedEsbuildPath = "/path/to/esbuild"
+
+      let config = {
+        Defaults.EsbuildConfig with
+            version = UMX.tag expectedVersion
+            ecmaVersion = expectedEcmaVersion
+      }
+
+      let decoded: DecodedEsbuild = {
+        externals = None
+        injects = None
+        minify = Some expectedMinify
+        version = None
+        ecmaVersion = None
+        fileLoaders = None
+        jsxAutomatic = None
+        esBuildPath = Some(UMX.tag expectedEsbuildPath)
+        jsxImportSource = None
+      }
+
+      let result = FromDecoders.GetEsbuild(config, Some decoded)
+
+      match result with
+      | Some {
+               externals = externals
+               injects = injects
+               minify = minify
+               version = version
+               ecmaVersion = ecmaVersion
+               fileLoaders = fileLoaders
+               jsxAutomatic = jsxAutomatic
+               esBuildPath = esBuildPath
+               jsxImportSource = jsxImportSource
+             } ->
+        Assert.Empty(externals)
+        Assert.Empty(injects)
+        Assert.Equal(expectedMinify, minify)
+        Assert.Equal(expectedVersion, version)
+        Assert.Equal(expectedEcmaVersion, ecmaVersion)
+        Assert.Equal(expectedEsbuildPath, UMX.untag esBuildPath)
+        Assert.Equal(UMX.untag config.version, UMX.untag version)
+        Assert.Equal(config.jsxImportSource, jsxImportSource)
+        Assert.Equal(config.jsxAutomatic, jsxAutomatic)
+        let loaders = fileLoaders :> IDictionary<string, string>
+
+        for KeyValue(expectedKey, expectedValue) in config.fileLoaders do
+          let value = Assert.Contains(expectedKey, loaders)
+          Assert.Equal(expectedValue, value)
+
+      | None -> Assert.Fail "Build config should be present"
+
+
+    [<Fact>]
+    let ``FromDecoders.GetTesting returns None if no DecodedBuild is present``
+      ()
+      =
+      let config = Defaults.TestConfig
+      let result = FromDecoders.GetTesting(config, None)
+      Assert.True(result.IsNone)
+
+
+    [<Fact>]
+    let ``FromDecoders.GetTesting returns DecodedBuild`` () =
+      let config = Defaults.TestConfig
+
+      let decoded: DecodedTesting = {
+        includes = None
+        excludes = None
+        browserMode = None
+        browsers = None
+        headless = None
+        watch = None
+        fable = None
+      }
+
+      let result = FromDecoders.GetTesting(config, Some decoded)
+
+      match result with
+      | Some {
+               includes = includes
+               excludes = excludes
+               browserMode = browserMode
+               browsers = browsers
+               headless = headless
+               watch = watch
+             } ->
+
+        Assert.Contains(Browser.Chromium, browsers)
+        Assert.Empty(excludes)
+
+        for expectedInclude in config.includes do
+          Assert.Contains(expectedInclude, includes)
+
+        Assert.Equal(config.watch, watch)
+        Assert.Equal(config.headless, headless)
+        Assert.Equal(config.browserMode, browserMode)
+        Assert.True(config.fable.IsNone)
+      | None -> Assert.Fail "Build config should be present"
+
+    [<Fact>]
+    let ``FromDecoders.GetTesting respects existing values`` () =
+      let expectedHeadless = true
+      let expectedBrowser = Browser.Firefox
+      let expectedBrowserMode = BrowserMode.Sequential
+      let expectedExclude = "**/*.no-test.js"
+
+      let config = {
+        Defaults.TestConfig with
+            headless = expectedHeadless
+            browsers = [ expectedBrowser ]
+            browserMode = BrowserMode.Parallel
+      }
+
+      let decoded: DecodedTesting = {
+        includes = None
+        excludes = Some [ expectedExclude ]
+        browserMode = Some expectedBrowserMode
+        browsers = None
+        headless = None
+        watch = None
+        fable = None
+      }
+
+      let result = FromDecoders.GetTesting(config, Some decoded)
+
+      match result with
+      | Some {
+               includes = includes
+               excludes = excludes
+               browserMode = browserMode
+               browsers = browsers
+               headless = headless
+               watch = watch
+             } ->
+        (expectedBrowser, Assert.Single(browsers)) |> Assert.Equal
+        (expectedExclude, Assert.Single(excludes)) |> Assert.Equal
+
+        for expectedInclude in config.includes do
+          Assert.Contains(expectedInclude, includes)
+
+        Assert.Equal(config.watch, watch)
+        Assert.Equal(expectedHeadless, headless)
+        Assert.Equal(expectedBrowserMode, browserMode)
+        Assert.True(config.fable.IsNone)
+      | None -> Assert.Fail "Build config should be present"
+
+  module FromFields =
+    open ConfigExtraction
+
+    [<Fact>]
+    let ``FromFields.GetServerFields gives you the default values`` () =
+      let config = Defaults.DevServerConfig
+      let serverOptions = FromFields.GetServerFields(config, None)
+
+      let expectedOptions = seq {
+        DevServerField.Port config.port
+        DevServerField.Host config.host
+        DevServerField.LiveReload config.liveReload
+        DevServerField.UseSSL config.useSSL
+      }
+
+      Assert.Equal<DevServerField>(expectedOptions, serverOptions)
+
+    [<Fact>]
+    let ``FromFields.GetServerFields gives you provided values`` () =
+      let config = Defaults.DevServerConfig
+
+      let expectedOptions = seq {
+        DevServerField.Port 1000
+        DevServerField.Host "0.0.0.0"
+      }
+
+      let serverOptions =
+        FromFields.GetServerFields(config, Some expectedOptions)
+
+      for expectedOption in expectedOptions do
+        Assert.Contains(expectedOption, serverOptions)
+
+
+    [<Fact>]
+    let ``FromFields.GetMinify Returns minification based on run config`` () =
+      let notMinified =
+        FromFields.GetMinify(RunConfiguration.Development, Seq.empty)
+
+      let minified =
+        FromFields.GetMinify(RunConfiguration.Production, Seq.empty)
+
+      Assert.False(notMinified)
+      Assert.True(minified)
+
+    [<Fact>]
+    let ``FromFields.GetMinify can extract MinifySources from field seq`` () =
+      let minified =
+        FromFields.GetMinify(
+          RunConfiguration.Development,
+          seq {
+            MinifySources true
+            DevServerField.Port 1000
+          }
+        )
+
+      let notMinified =
+        FromFields.GetMinify(
+          RunConfiguration.Production,
+          seq {
+            MinifySources false
+            DevServerField.Port 1000
+          }
+        )
+
+      Assert.True(minified)
+      Assert.False(notMinified)
+
+    [<Fact>]
+    let ``FromFields.GetDevServerOptions returns the same config passed if the fields are empty``
+      ()
+      =
+      let options =
+        FromFields.GetDevServerOptions(Defaults.DevServerConfig, Seq.empty)
+
+      Assert.Equal(Defaults.DevServerConfig, options)
+
+    [<Fact>]
+    let ``FromFields.GetDevServerOptions can extract DevServer Options from field seq``
+      ()
+      =
+
+      let expectedOptions = {
+        Defaults.DevServerConfig with
+            port = 1000
+            host = "0.0.0.0"
+      }
+
+      let options =
+        FromFields.GetDevServerOptions(
+          Defaults.DevServerConfig,
+          seq {
+            DevServerField.Host "0.0.0.0"
+            DevServerField.Port 1000
+          }
+        )
+
+      Assert.Equal(expectedOptions, options)
+
+    [<Fact>]
+    let ``FromFields.GetTesting returns the same config passed if the fields are empty``
+      ()
+      =
+      let options = FromFields.GetTesting(Defaults.TestConfig, None)
+      Assert.Equal<Browser>(Defaults.TestConfig.browsers, options.browsers)
+      Assert.Equal<string>(Defaults.TestConfig.includes, options.includes)
+      Assert.Equal<string>(Defaults.TestConfig.excludes, options.excludes)
+      Assert.Equal(Defaults.TestConfig.watch, options.watch)
+      Assert.Equal(Defaults.TestConfig.headless, options.headless)
+      Assert.Equal(Defaults.TestConfig.browserMode, options.browserMode)
+      Assert.Equal(Defaults.TestConfig.fable, options.fable)
+
+    [<Fact>]
+    let ``FromFields.GetTesting can extract DevServer Options from field seq``
+      ()
+      =
+
+      let expectedOptions = {
+        Defaults.TestConfig with
+            browsers = [ Browser.Firefox ]
+            headless = false
+      }
+
+      let options =
+        FromFields.GetTesting(
+          Defaults.TestConfig,
+          Some(
+            seq {
+              TestingField.Browsers [ Browser.Firefox ]
+              TestingField.Headless false
+            }
+          )
+        )
+
+      Assert.Equal<Browser>(expectedOptions.browsers, options.browsers)
+      Assert.Equal<string>(expectedOptions.includes, options.includes)
+      Assert.Equal<string>(expectedOptions.excludes, options.excludes)
+      Assert.Equal(expectedOptions.watch, options.watch)
+      Assert.Equal(expectedOptions.headless, options.headless)
+      Assert.Equal(expectedOptions.browserMode, options.browserMode)
+      Assert.Equal(expectedOptions.fable, options.fable)
 
   // we're not picking up env variables yet for perla config
   [<Fact>]
   let ``fromEnv returns the same config passed`` () =
     let config = Defaults.PerlaConfig
-    Assert.Equal(config, fromEnv config)
+    Assert.Equal(config, ConfigExtraction.FromEnv config)
 
   [<Fact>]
   let ``fromFile should update devServer options in perla config`` () =
@@ -33,7 +617,7 @@ module Configuration =
 }"""
 
     let parsedConfig = Json.getConfigDocument configText
-    let result = Configuration.fromFile (Some parsedConfig) config
+    let result = ConfigExtraction.FromFile (Some parsedConfig) config
 
     Assert.Equal(
       result,

--- a/tests/Perla.Tests/Perla.Tests.fsproj
+++ b/tests/Perla.Tests/Perla.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #106 and #105

- add paths config option
- Add paths to writable field Improve tests for Configuration file
- add two new debug configs
- add resolution command
- add resolution handler
- enable resolution command
- make the bare import external
- add bare import constant for env
- remove "internal" from functions add aliases option ensure esbuild runs in the correct cwd when using build keep names for transform api
- change missing name
- add import map helpers to add/remove paths and env from the imports in the map
- ensure paths and env correctly resolve
