### PR TITLE
Feature/show different tempalte options

### DIFF
--- a/sample/src/App.fsproj
+++ b/sample/src/App.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Perla/CliMiddleware.fs
+++ b/src/Perla/CliMiddleware.fs
@@ -296,7 +296,7 @@ module Middleware =
           env.RunSetupTemplates(
             {
               fullRepositoryName =
-                $"{Default_Templates_Repository}:{Default_Templates_Repository_Branch}"
+                Some $"{Default_Templates_Repository}:{Default_Templates_Repository_Branch}"
               operation = RunTemplateOperation.Add
             },
             cancellationToken

--- a/src/Perla/CliMiddleware.fs
+++ b/src/Perla/CliMiddleware.fs
@@ -296,7 +296,8 @@ module Middleware =
           env.RunSetupTemplates(
             {
               fullRepositoryName =
-                Some $"{Default_Templates_Repository}:{Default_Templates_Repository_Branch}"
+                Some
+                  $"{Default_Templates_Repository}:{Default_Templates_Repository_Branch}"
               operation = RunTemplateOperation.Add
             },
             cancellationToken

--- a/src/Perla/CliMiddleware.fsi
+++ b/src/Perla/CliMiddleware.fsi
@@ -79,6 +79,7 @@ module Middleware =
         bool
 
     val ToSCLMiddleware: middleware: PerlaCliMiddleware -> InvocationMiddleware
+
     val previewCheck:
       command: Command * directives: KeyValuePair<string, string seq> seq ->
         Task<Result<unit, PerlaMdResult>>

--- a/src/Perla/Commands.fs
+++ b/src/Perla/Commands.fs
@@ -294,7 +294,7 @@ module PackageInputs =
   let showAsNpm: HandlerInput<bool option> =
     Input.OptionMaybe(
       [ "--npm"; "--as-package-json"; "-j" ],
-      "Show the packages simlar to npm's package.json"
+      "Show the packages similar to npm's package.json"
     )
 
 [<RequireQualifiedAccess>]
@@ -302,7 +302,7 @@ module TemplateInputs =
   let repositoryName: HandlerInput<string option> =
     Input.ArgumentMaybe(
       "templateRepositoryName",
-      "The User/repository name combination"
+      "The User/repository name combination or ID of the template"
     )
 
   let addTemplate: HandlerInput<bool option> =

--- a/src/Perla/Commands.fs
+++ b/src/Perla/Commands.fs
@@ -299,8 +299,8 @@ module PackageInputs =
 
 [<RequireQualifiedAccess>]
 module TemplateInputs =
-  let repositoryName: HandlerInput<string> =
-    Input.Argument(
+  let repositoryName: HandlerInput<string option> =
+    Input.ArgumentMaybe(
       "templateRepositoryName",
       "The User/repository name combination"
     )
@@ -713,7 +713,7 @@ module Commands =
     let buildArgs
       (
         ctx: InvocationContext,
-        name: string,
+        name: string option,
         add: bool option,
         update: bool option,
         remove: bool option,
@@ -749,7 +749,7 @@ module Commands =
         |> Option.defaultValue format
 
       {
-        fullRepositoryName = name
+        fullRepositoryName = name |> Option.defaultValue ""
         operation = operation
       },
       ctx.GetCancellationToken()

--- a/src/Perla/Commands.fs
+++ b/src/Perla/Commands.fs
@@ -332,12 +332,6 @@ module ProjectInputs =
   let projectName: HandlerInput<string> =
     Input.Argument("name", "Name of the new project")
 
-  let templateName: HandlerInput<string option> =
-    Input.OptionMaybe(
-      [ "-tn"; "--template-name" ],
-      "repository/directory combination of the template name, or the full name in case of name conflicts username/repository/directory"
-    )
-
   let byId: HandlerInput<string option> =
     Input.OptionMaybe(
       [ "-id"; "--group-id" ],
@@ -786,13 +780,11 @@ module Commands =
       (
         ctx: InvocationContext,
         name: string,
-        template: string option,
         byId: string option,
         byShortName: string option
       ) : ProjectOptions * CancellationToken =
       {
         projectName = name
-        byTemplateName = template
         byId = byId
         byShortName = byShortName
       },
@@ -807,7 +799,6 @@ module Commands =
       inputs (
         Input.Context(),
         ProjectInputs.projectName,
-        ProjectInputs.templateName,
         ProjectInputs.byId,
         ProjectInputs.byShortName
       )

--- a/src/Perla/Commands.fs
+++ b/src/Perla/Commands.fs
@@ -302,7 +302,7 @@ module TemplateInputs =
   let repositoryName: HandlerInput<string option> =
     Input.ArgumentMaybe(
       "templateRepositoryName",
-      "The User/repository name combination or ID of the template"
+      "The User/repository name combination"
     )
 
   let addTemplate: HandlerInput<bool option> =
@@ -749,7 +749,7 @@ module Commands =
         |> Option.defaultValue format
 
       {
-        fullRepositoryName = name |> Option.defaultValue ""
+        fullRepositoryName = name
         operation = operation
       },
       ctx.GetCancellationToken()

--- a/src/Perla/Commands.fsi
+++ b/src/Perla/Commands.fsi
@@ -59,7 +59,7 @@ module PackageInputs =
 
 [<RequireQualifiedAccess>]
 module TemplateInputs =
-  val repositoryName: HandlerInput<string>
+  val repositoryName: HandlerInput<string option>
   val addTemplate: HandlerInput<bool option>
   val updateTemplate: HandlerInput<bool option>
   val removeTemplate: HandlerInput<bool option>

--- a/src/Perla/Commands.fsi
+++ b/src/Perla/Commands.fsi
@@ -68,7 +68,6 @@ module TemplateInputs =
 [<RequireQualifiedAccess>]
 module ProjectInputs =
   val projectName: HandlerInput<string>
-  val templateName: HandlerInput<string option>
   val byId: HandlerInput<string option>
   val byShortName: HandlerInput<string option>
 

--- a/src/Perla/Configuration.fsi
+++ b/src/Perla/Configuration.fsi
@@ -59,17 +59,29 @@ module internal ConfigExtraction =
   module FromDecoders =
     open Json.ConfigDecoders
 
-    val GetFable: FableConfig option * DecodedFableConfig option -> FableConfig option
-    val GetDevServer: DevServerConfig * DecodedDevServer option -> DevServerConfig option
+    val GetFable:
+      FableConfig option * DecodedFableConfig option -> FableConfig option
+
+    val GetDevServer:
+      DevServerConfig * DecodedDevServer option -> DevServerConfig option
+
     val GetBuild: BuildConfig * DecodedBuild option -> BuildConfig option
-    val GetEsbuild: EsbuildConfig * DecodedEsbuild option -> EsbuildConfig option
+
+    val GetEsbuild:
+      EsbuildConfig * DecodedEsbuild option -> EsbuildConfig option
+
     val GetTesting: TestConfig * DecodedTesting option -> TestConfig option
 
   [<RequireQualifiedAccess>]
   module FromFields =
-    val GetServerFields: DevServerConfig * DevServerField seq option -> DevServerField seq
+    val GetServerFields:
+      DevServerConfig * DevServerField seq option -> DevServerField seq
+
     val GetMinify: RunConfiguration * DevServerField seq -> bool
-    val GetDevServerOptions: DevServerConfig * DevServerField seq -> DevServerConfig
+
+    val GetDevServerOptions:
+      DevServerConfig * DevServerField seq -> DevServerConfig
+
     val GetTesting: TestConfig * TestingField seq option -> TestConfig
 
   val FromEnv: config: PerlaConfig -> PerlaConfig

--- a/src/Perla/FileSystem.fs
+++ b/src/Perla/FileSystem.fs
@@ -243,8 +243,7 @@ module FileSystem =
         let extract () =
           use stream = new GZipInputStream(File.OpenRead path)
 
-          use archive =
-            TarArchive.CreateInputTarArchive(stream, Encoding.UTF8)
+          use archive = TarArchive.CreateInputTarArchive(stream, Encoding.UTF8)
 
           path |> Path.GetDirectoryName |> archive.ExtractContents
 

--- a/src/Perla/FileSystem.fsi
+++ b/src/Perla/FileSystem.fsi
@@ -54,7 +54,9 @@ module FileSystem =
   val TplRepositoryChildTemplates:
     path: string<SystemPath> -> string<SystemPath> seq
 
-  val DotNetToolRestore: cancellationToken: CancellationToken -> Task<Result<unit, string>>
+  val DotNetToolRestore:
+    cancellationToken: CancellationToken -> Task<Result<unit, string>>
+
   val CheckFableExists: cancellationToken: CancellationToken -> Task<bool>
 
 [<Class>]

--- a/src/Perla/Handlers.fs
+++ b/src/Perla/Handlers.fs
@@ -95,7 +95,7 @@ type RunTemplateOperation =
   | List of ListFormat
 
 type TemplateRepositoryOptions = {
-  fullRepositoryName: string
+  fullRepositoryName: string option
   operation: RunTemplateOperation
 }
 

--- a/src/Perla/Handlers.fs
+++ b/src/Perla/Handlers.fs
@@ -187,12 +187,7 @@ module Templates =
       let table =
         Table()
           .AddColumns(
-            [|
-              "Name"
-              "perla new -t"
-              "perla new -id"
-              "Repository name"
-            |]
+            [| "Name"; "perla new -t"; "perla new -id"; "Repository name" |]
           )
 
       for column in table.Columns do
@@ -204,16 +199,16 @@ module Templates =
 
         let shortname = Markup($"[bold yellow]{template.shortName}[/]")
         let group = Markup($"[bold blue]{template.group}[/]")
-        let repositoryName = Markup($"[bold blue]{parent.ToFullNameWithBranch}[/]")
 
-        table.AddRow([| name; shortname; group; repositoryName |])
-        |> ignore
+        let repositoryName =
+          Markup($"[bold blue]{parent.ToFullNameWithBranch}[/]")
+
+        table.AddRow([| name; shortname; group; repositoryName |]) |> ignore
 
       AnsiConsole.Write table
       0
     | ListFormat.TextOnly ->
-      let columns =
-        Columns([|"Name";"perla new -t";"perla new -id"|])
+      let columns = Columns([| "Name"; "perla new -t"; "perla new -id" |])
 
       AnsiConsole.Write columns
 
@@ -222,9 +217,17 @@ module Templates =
           let name = Markup($"[bold green]{template.name}[/]")
           let shortname = Markup($"[bold yellow]{template.shortName}[/]")
           let group = Markup($"[bold blue]{template.group}[/]")
-          let repositoryName = TextPath(UMX.untag parent.ToFullNameWithBranch, LeafStyle=Style(Color.Green),StemStyle=Style(Color.Yellow),SeparatorStyle = Style(Color.Blue))
 
-          Columns(name, shortname, group, repositoryName) :> Rendering.IRenderable
+          let repositoryName =
+            TextPath(
+              UMX.untag parent.ToFullNameWithBranch,
+              LeafStyle = Style(Color.Green),
+              StemStyle = Style(Color.Yellow),
+              SeparatorStyle = Style(Color.Blue)
+            )
+
+          Columns(name, shortname, group, repositoryName)
+          :> Rendering.IRenderable
       |]
 
       rows |> Rows |> AnsiConsole.Write

--- a/src/Perla/Handlers.fs
+++ b/src/Perla/Handlers.fs
@@ -101,7 +101,6 @@ type TemplateRepositoryOptions = {
 
 type ProjectOptions = {
   projectName: string
-  byTemplateName: string option
   byId: string option
   byShortName: string option
 }
@@ -591,14 +590,10 @@ module Handlers =
       |> Option.map UMX.tag<TemplateGroup>
       |> Option.map QuickAccessSearch.Group
 
-    let inline byTemplateName () =
-      options.byTemplateName |> Option.map QuickAccessSearch.Name
-
     let queryParam =
       options.byShortName
       |> Option.map QuickAccessSearch.ShortName
       |> Option.orElseWith byId
-      |> Option.orElseWith byTemplateName
 
     let foundRepo = result {
       let! query = queryParam |> Result.requireSome Templates.NoQueryParams

--- a/src/Perla/Handlers.fs
+++ b/src/Perla/Handlers.fs
@@ -741,15 +741,25 @@ module Handlers =
       }
 
       let updateRepo () = task {
-        let template = template.Value
-        Logger.log $"Template {template.ToFullNameWithBranch} already exists."
+        match template with
+        | ValueSome template ->
+          Logger.log $"Template {template.ToFullNameWithBranch} already exists."
 
-        match!
-          Templates.AddOrUpdate(Templates.TemplateOperation.Update template)
-        with
-        | Ok() -> return 0
-        | Error err ->
-          Logger.log (err, escape = false)
+          match!
+            Templates.AddOrUpdate(Templates.TemplateOperation.Update template)
+          with
+          | Ok() -> return 0
+          | Error err ->
+            Logger.log (err, escape = false)
+            return 1
+        | ValueNone ->
+          Logger.log "We were unable to parse the repository name."
+
+          Logger.log (
+            "please ensure that the repository name is in the format: [bold blue]username/repository:branch[/]",
+            escape = false
+          )
+
           return 1
       }
 

--- a/src/Perla/Handlers.fsi
+++ b/src/Perla/Handlers.fsi
@@ -93,12 +93,12 @@ type DescribeOptions = {
 
 [<Struct>]
 type PathOperation =
-  | AddOrUpdate of addImport: string<BareImport> * addPath: string<ResolutionUrl>
+  | AddOrUpdate of
+    addImport: string<BareImport> *
+    addPath: string<ResolutionUrl>
   | Remove of removeImport: string
 
-type PathsOptions = {
-  operation: PathOperation
-}
+type PathsOptions = { operation: PathOperation }
 
 module Handlers =
 

--- a/src/Perla/Handlers.fsi
+++ b/src/Perla/Handlers.fsi
@@ -62,7 +62,7 @@ type RunTemplateOperation =
   | List of ListFormat
 
 type TemplateRepositoryOptions = {
-  fullRepositoryName: string
+  fullRepositoryName: string option
   operation: RunTemplateOperation
 }
 

--- a/src/Perla/Handlers.fsi
+++ b/src/Perla/Handlers.fsi
@@ -68,7 +68,6 @@ type TemplateRepositoryOptions = {
 
 type ProjectOptions = {
   projectName: string
-  byTemplateName: string option
   byId: string option
   byShortName: string option
 }

--- a/src/Perla/Library.fs
+++ b/src/Perla/Library.fs
@@ -76,19 +76,18 @@ module Lib =
       ValueSome(Provider.Unpkg, name, $"{version}{preview}")
     | _ -> ValueNone
 
-  let parseFullRepositoryName (value: string option) =
-    voption {
-      let! name = value
-      let regex = Regex(@"^([-_\w\d]+)\/([-_\w\d]+):?([\w\d-_]+)?$")
+  let parseFullRepositoryName (value: string option) = voption {
+    let! name = value
+    let regex = Regex(@"^([-_\w\d]+)\/([-_\w\d]+):?([\w\d-_]+)?$")
 
-      return!
-        match name with
-        | ParseRegex regex [ username; repository; branch ] ->
-          ValueSome(username, repository, branch)
-        | ParseRegex regex [ username; repository ] ->
-          ValueSome(username, repository, "main")
-        | _ -> ValueNone
-    }
+    return!
+      match name with
+      | ParseRegex regex [ username; repository; branch ] ->
+        ValueSome(username, repository, branch)
+      | ParseRegex regex [ username; repository ] ->
+        ValueSome(username, repository, "main")
+      | _ -> ValueNone
+  }
 
   let getTemplateAndChild (templateName: string) =
     match

--- a/src/Perla/Library.fs
+++ b/src/Perla/Library.fs
@@ -5,6 +5,7 @@ open Spectre.Console.Rendering
 open FSharp.UMX
 open Perla.Units
 open Perla.PackageManager.Types
+open FsToolkit.ErrorHandling
 
 module private ImportMap =
 
@@ -75,15 +76,19 @@ module Lib =
       ValueSome(Provider.Unpkg, name, $"{version}{preview}")
     | _ -> ValueNone
 
-  let parseFullRepositoryName (value: string) =
-    let regex = Regex(@"^([-_\w\d]+)\/([-_\w\d]+):?([\w\d-_]+)?$")
+  let parseFullRepositoryName (value: string option) =
+    voption {
+      let! name = value
+      let regex = Regex(@"^([-_\w\d]+)\/([-_\w\d]+):?([\w\d-_]+)?$")
 
-    match value with
-    | ParseRegex regex [ username; repository; branch ] ->
-      ValueSome(username, repository, branch)
-    | ParseRegex regex [ username; repository ] ->
-      ValueSome(username, repository, "main")
-    | _ -> ValueNone
+      return!
+        match name with
+        | ParseRegex regex [ username; repository; branch ] ->
+          ValueSome(username, repository, branch)
+        | ParseRegex regex [ username; repository ] ->
+          ValueSome(username, repository, "main")
+        | _ -> ValueNone
+    }
 
   let getTemplateAndChild (templateName: string) =
     match

--- a/src/Perla/Library.fsi
+++ b/src/Perla/Library.fsi
@@ -20,7 +20,7 @@ module Lib =
     url: string -> (Provider * string * string) voption
 
   val internal parseFullRepositoryName:
-    value: string -> (string * string * string) voption
+    value: string option -> (string * string * string) voption
 
   val internal getTemplateAndChild:
     templateName: string -> string option * string * string option

--- a/src/Perla/Properties/launchSettings.json
+++ b/src/Perla/Properties/launchSettings.json
@@ -88,6 +88,11 @@
       "commandName": "Project",
       "commandLineArgs": "add @esm-bundle/chai -d",
       "workingDirectory": "$(ProjectDir)/../../sample"
+    },
+    "Show templates in table": {
+      "commandName": "Project",
+      "commandLineArgs": "t foo -ls table",
+      "workingDirectory": "$(ProjectDir)/../../sample"
     }
   }
 }

--- a/src/Perla/Scaffolding.fs
+++ b/src/Perla/Scaffolding.fs
@@ -95,10 +95,10 @@ module Scaffolding =
   [<RequireQualifiedAccess>]
   type QuickAccessSearch =
     | Id of ObjectId
-    | Name of string // TODO ask: remove from search as well?
+    | Name of string
     | Group of string<TemplateGroup>
     | ShortName of string
-    | Parent of ObjectId // TODO ask: remove from search as well?
+    | Parent of ObjectId
 
   [<RequireQualifiedAccess; Struct>]
   type TemplateScriptKind =

--- a/src/Perla/Scaffolding.fs
+++ b/src/Perla/Scaffolding.fs
@@ -95,10 +95,10 @@ module Scaffolding =
   [<RequireQualifiedAccess>]
   type QuickAccessSearch =
     | Id of ObjectId
-    | Name of string
+    | Name of string // TODO ask: remove from search as well?
     | Group of string<TemplateGroup>
     | ShortName of string
-    | Parent of ObjectId
+    | Parent of ObjectId // TODO ask: remove from search as well?
 
   [<RequireQualifiedAccess; Struct>]
   type TemplateScriptKind =

--- a/tests/Perla.Tests/CommandOptions.fs
+++ b/tests/Perla.Tests/CommandOptions.fs
@@ -343,18 +343,6 @@ module CommandOptions =
     Assert.Equal(expectedVersion, version.Value)
 
   [<Theory>]
-  [<InlineData("-tn", "username/repository/directory", "username/repository/directory")>]
-  [<InlineData("--template-name", "username/repository/directory", "username/repository/directory")>]
-  let ``Commands.NewProject can parse template name options`` (option: string, name: string, expectedTemplateName: string) =
-    let result =
-      ParseRootCommand(Commands.NewProject, $"new MyTestProject {option} {name}")
-
-    let templateName: string option = ProjectInputs.templateName.GetValue result
-
-    Assert.Empty(result.Errors)
-    Assert.Equal(expectedTemplateName, templateName.Value)
-
-  [<Theory>]
   [<InlineData("-id", "perla.templates.vanilla.js", "perla.templates.vanilla.js")>]
   [<InlineData("--group-id", "perla.templates.vanilla.js", "perla.templates.vanilla.js")>]
   let ``Commands.NewProject can parse group id options`` (option: string, name: string, expectedGroupId: string) =

--- a/tests/Perla.Tests/CommandOptions.fs
+++ b/tests/Perla.Tests/CommandOptions.fs
@@ -153,10 +153,10 @@ module CommandOptions =
 
   [<Fact>]
   let ``Commands.Setup can parse options`` () =
-    let result =
-      ParseRootCommand(Commands.Setup, "setup -y -t false")
+    let result = ParseRootCommand(Commands.Setup, "setup -y -t false")
 
-    let installTemplates: bool option = SetupInputs.installTemplates.GetValue result
+    let installTemplates: bool option =
+      SetupInputs.installTemplates.GetValue result
 
     let skipPrompts: bool option = SetupInputs.skipPrompts.GetValue result
 
@@ -168,7 +168,8 @@ module CommandOptions =
   let ``Parse Commands.Setup without options should not fail`` () =
     let result = ParseRootCommand(Commands.Setup, "setup")
 
-    let installTemplates: bool option = SetupInputs.installTemplates.GetValue result
+    let installTemplates: bool option =
+      SetupInputs.installTemplates.GetValue result
 
     let skipPrompts: bool option = SetupInputs.skipPrompts.GetValue result
 
@@ -344,10 +345,20 @@ module CommandOptions =
 
   [<Theory>]
   [<InlineData("-id", "perla.templates.vanilla.js", "perla.templates.vanilla.js")>]
-  [<InlineData("--group-id", "perla.templates.vanilla.js", "perla.templates.vanilla.js")>]
-  let ``Commands.NewProject can parse group id options`` (option: string, name: string, expectedGroupId: string) =
+  [<InlineData("--group-id",
+               "perla.templates.vanilla.js",
+               "perla.templates.vanilla.js")>]
+  let ``Commands.NewProject can parse group id options``
+    (
+      option: string,
+      name: string,
+      expectedGroupId: string
+    ) =
     let result =
-      ParseRootCommand(Commands.NewProject, $"new MyTestProject {option} {name}")
+      ParseRootCommand(
+        Commands.NewProject,
+        $"new MyTestProject {option} {name}"
+      )
 
     let groupId: string option = ProjectInputs.byId.GetValue result
 
@@ -357,9 +368,17 @@ module CommandOptions =
   [<Theory>]
   [<InlineData("-t", "ff", "ff")>]
   [<InlineData("--template", "ff", "ff")>]
-  let ``Commands.NewProject can parse shortname options`` (option: string, name: string, expectedShortName: string) =
+  let ``Commands.NewProject can parse shortname options``
+    (
+      option: string,
+      name: string,
+      expectedShortName: string
+    ) =
     let result =
-      ParseRootCommand(Commands.NewProject, $"new MyTestProject {option} {name}")
+      ParseRootCommand(
+        Commands.NewProject,
+        $"new MyTestProject {option} {name}"
+      )
 
     let shortname: string option = ProjectInputs.byShortName.GetValue result
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3847895/233936880-7ff0b35b-7050-46aa-b306-c402afb47f0d.png)


Ref: https://github.com/AngelMunoz/Perla/issues/120

Hi. This PR changes the template option to show the shortname and the group in addition to the repository name. I know in the issue we talked about removing the template name from the output, but I decided to keep it since that is what's needed for the `update` and `remove` options