### PR TITLE
Refactor plugin registry and fsi session management

### DIFF
--- a/Perla.sln
+++ b/Perla.sln
@@ -45,6 +45,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Perla.Tests", "tests\Perla.
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "App.Tests", "sample\tests\App.Tests.fsproj", "{477DC1B0-AAA6-4F1C-B7D3-F81599301EF2}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Perla.Plugins.Tests", "tests\Perla.Plugins.Tests\Perla.Plugins.Tests.fsproj", "{54110CE2-44E1-4F23-922A-B787AE4EE942}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -151,6 +153,18 @@ Global
 		{477DC1B0-AAA6-4F1C-B7D3-F81599301EF2}.Release|x64.Build.0 = Release|Any CPU
 		{477DC1B0-AAA6-4F1C-B7D3-F81599301EF2}.Release|x86.ActiveCfg = Release|Any CPU
 		{477DC1B0-AAA6-4F1C-B7D3-F81599301EF2}.Release|x86.Build.0 = Release|Any CPU
+		{54110CE2-44E1-4F23-922A-B787AE4EE942}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54110CE2-44E1-4F23-922A-B787AE4EE942}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54110CE2-44E1-4F23-922A-B787AE4EE942}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{54110CE2-44E1-4F23-922A-B787AE4EE942}.Debug|x64.Build.0 = Debug|Any CPU
+		{54110CE2-44E1-4F23-922A-B787AE4EE942}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{54110CE2-44E1-4F23-922A-B787AE4EE942}.Debug|x86.Build.0 = Debug|Any CPU
+		{54110CE2-44E1-4F23-922A-B787AE4EE942}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54110CE2-44E1-4F23-922A-B787AE4EE942}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54110CE2-44E1-4F23-922A-B787AE4EE942}.Release|x64.ActiveCfg = Release|Any CPU
+		{54110CE2-44E1-4F23-922A-B787AE4EE942}.Release|x64.Build.0 = Release|Any CPU
+		{54110CE2-44E1-4F23-922A-B787AE4EE942}.Release|x86.ActiveCfg = Release|Any CPU
+		{54110CE2-44E1-4F23-922A-B787AE4EE942}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -164,6 +178,7 @@ Global
 		{47282206-8708-40D9-B719-244917138D8C} = {8A91A834-42C4-4F4E-96F7-2A3F6EEAF86D}
 		{34AE674A-CE46-4542-AF7B-9AD5D87A97B1} = {5C4E5179-198B-45FD-B3B2-6ACF362AA793}
 		{477DC1B0-AAA6-4F1C-B7D3-F81599301EF2} = {8A91A834-42C4-4F4E-96F7-2A3F6EEAF86D}
+		{54110CE2-44E1-4F23-922A-B787AE4EE942} = {5C4E5179-198B-45FD-B3B2-6ACF362AA793}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7D4871D9-18C5-4755-8967-0F93A78C7715}

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -48,6 +48,14 @@ group Samples
     nuget Fable.Browser.Dom >= 2.14.0
     nuget Fable.Browser.Event >= 1.5.0
 
+group Plugins
+    source https://api.nuget.org/v3/index.json
+
+    nuget FSharp.Compiler.Service
+    nuget FSharp.Control.AsyncSeq
+    nuget FsToolkit.ErrorHandling
+    nuget IcedTasks
+
 group Tests
     source https://api.nuget.org/v3/index.json
 

--- a/paket.lock
+++ b/paket.lock
@@ -279,6 +279,52 @@ NUGET
   remote: https://api.nuget.org/v3/index.json
     FSharp.Core (8.0.100)
 
+GROUP Plugins
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    FSharp.Compiler.Service (43.8.100)
+      FSharp.Core (8.0.100) - restriction: >= netstandard2.0
+      System.Buffers (>= 4.5.1) - restriction: >= netstandard2.0
+      System.Collections.Immutable (>= 7.0) - restriction: >= netstandard2.0
+      System.Diagnostics.DiagnosticSource (>= 7.0.2) - restriction: >= netstandard2.0
+      System.Memory (>= 4.5.5) - restriction: >= netstandard2.0
+      System.Reflection.Emit (>= 4.7) - restriction: >= netstandard2.0
+      System.Reflection.Metadata (>= 7.0) - restriction: >= netstandard2.0
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: >= netstandard2.0
+    FSharp.Control.AsyncSeq (3.2.1)
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
+      Microsoft.Bcl.AsyncInterfaces (>= 5.0) - restriction: >= netstandard2.0
+    FSharp.Core (8.0.100) - restriction: >= netstandard2.0
+    FsToolkit.ErrorHandling (4.11)
+      FSharp.Core (>= 7.0.300) - restriction: >= netstandard2.1
+      FSharp.Core (>= 7.0.400) - restriction: && (>= netstandard2.0) (< netstandard2.1)
+    IcedTasks (0.9.2)
+      FSharp.Core (>= 6.0.1) - restriction: >= netstandard2.0
+    Microsoft.Bcl.AsyncInterfaces (8.0) - restriction: >= netstandard2.0
+      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net462) (&& (>= netstandard2.0) (< netstandard2.1))
+    System.Buffers (4.5.1) - restriction: >= netstandard2.0
+    System.Collections.Immutable (8.0) - restriction: >= netstandard2.0
+      System.Memory (>= 4.5.5) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net462) (&& (>= net6.0) (< net7.0)) (&& (< net6.0) (>= netstandard2.0))
+    System.Diagnostics.DiagnosticSource (8.0) - restriction: >= netstandard2.0
+      System.Memory (>= 4.5.5) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net462) (&& (>= net6.0) (< net7.0)) (&& (< net6.0) (>= netstandard2.0))
+    System.Memory (4.5.5) - restriction: >= netstandard2.0
+      System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard1.1)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Numerics.Vectors (>= 4.4) - restriction: && (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+      System.Numerics.Vectors (>= 4.5) - restriction: >= net461
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (>= monoandroid) (< netstandard1.1)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+    System.Numerics.Vectors (4.5) - restriction: || (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net461) (>= netstandard2.0))
+    System.Reflection.Emit (4.7) - restriction: >= netstandard2.0
+      System.Reflection.Emit.ILGeneration (>= 4.7) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1)
+    System.Reflection.Emit.ILGeneration (4.7) - restriction: || (&& (< monoandroid) (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (>= netstandard2.0) (>= uap10.1))
+    System.Reflection.Metadata (8.0) - restriction: >= netstandard2.0
+      System.Collections.Immutable (>= 8.0) - restriction: || (>= net462) (>= netstandard2.0)
+      System.Memory (>= 4.5.5) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+    System.Runtime.CompilerServices.Unsafe (6.0) - restriction: || (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= net6.0) (< net7.0)) (>= netstandard2.0)
+    System.Threading.Tasks.Extensions (4.5.4) - restriction: || (&& (>= net462) (>= netstandard2.0)) (&& (>= netstandard2.0) (< netstandard2.1))
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< win8)) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net461) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= wp8)
+
 GROUP Samples
 NUGET
   remote: https://api.nuget.org/v3/index.json

--- a/src/Perla.Plugins/Registry.fs
+++ b/src/Perla.Plugins/Registry.fs
@@ -12,6 +12,13 @@ open FsToolkit.ErrorHandling
 
 open Perla.Plugins
 
+[<Struct>]
+type PluginLoadError =
+  | SessionExists
+  | BoundValueMissing
+  | EvaluationFailed of evalFailure: exn
+  | NoPluginFound of pluginName: string
+
 module SessionFactory =
   let inline create stdout stderr =
     FsiEvaluationSession.Create(
@@ -26,77 +33,32 @@ module SessionFactory =
 module ScriptReflection =
   let inline findPlugin (fsi: FsiEvaluationSession) =
     match fsi.TryFindBoundValue "Plugin", fsi.TryFindBoundValue "plugin" with
-    | Some bound, _ -> ValueSome bound.Value
-    | None, Some bound -> ValueSome bound.Value
-    | None, None -> ValueNone
+    | Some bound, _ -> Some bound.Value
+    | None, Some bound -> Some bound.Value
+    | None, None -> None
 
-type SessionManager private () =
-  let stdout = Unchecked.defaultof<_>
-  let stderr = Unchecked.defaultof<_>
+type SessionCache<'Cache
+  when 'Cache: (static member SessionCache:
+    Dictionary<string, FsiEvaluationSession>)> = 'Cache
 
-  let cache = Dictionary<string, FsiEvaluationSession>()
+type PluginCache<'Cache
+  when 'Cache: (static member PluginCache: Dictionary<string, PluginInfo>)> =
+  'Cache
 
-  private new(stdout, stderr: TextWriter) = new SessionManager(stdout, stderr)
+type StdoutStderr<'Writer
+  when 'Writer: (static member Stdout: TextWriter)
+  and 'Writer: (static member Stderr: TextWriter)> = 'Writer
 
 
-  static member Create() =
-    new SessionManager(Console.Out, Console.Error)
+[<RequireQualifiedAccess>]
+module PluginRegistry =
 
-  static member Create(stdout: StringWriter, stderr: StringWriter) =
-    new SessionManager(stdout, stderr)
-
-  static member Create(stdout, stderr) =
-    new SessionManager(
-      new StringWriter(stdout, Globalization.CultureInfo.InvariantCulture),
-      new StringWriter(stderr, Globalization.CultureInfo.InvariantCulture)
-    )
-
-  member _.LoadFromText(id, content, ?token) =
-    match cache.TryGetValue(id) with
-    | true, _ -> ValueNone
-    | false, _ ->
-      let session = SessionFactory.create stdout stderr
-
-      let evaluation, _ =
-        session.EvalInteractionNonThrowing(content, ?cancellationToken = token)
-
-      let evalResult =
-        evaluation
-        |> Result.ofChoice
-        |> Result.map (fun value -> ValueOption.ofOption value)
-        |> Result.teeError (fun err -> stdout.WriteLine(err))
-        |> Result.toValueOption
-        |> ValueOption.defaultWith (fun _ ->
-          ScriptReflection.findPlugin session)
-
-      match evalResult with
-      | ValueSome value when value.ReflectionType = typeof<PluginInfo> ->
-        cache.Add(id, session)
-
-        let plugin: PluginInfo = unbox value.ReflectionValue
-        cache.Add(id, session)
-
-        ValueSome plugin
-      | _ -> ValueNone
-
-  interface IDisposable with
-    member _.Dispose() =
-      for session in cache.Values do
-        (session :> IDisposable).Dispose()
-
-type PluginRegistry() =
-
-  let plugins = Dictionary<string, PluginInfo>()
-
-  member _.TryRegister plugin = plugins.TryAdd(plugin.name, plugin)
-
-  member _.GetRunnables order = [
+  let inline GetRunnablePlugins<'Cache when PluginCache<'Cache>> order = [
     for name in order do
-      match plugins.TryGetValue(name) with
+      match 'Cache.PluginCache.TryGetValue(name) with
       | true, plugin ->
         match plugin.shouldProcessFile, plugin.transform with
-        | ValueSome st, ValueSome t ->
-          yield {
+        | ValueSome st, ValueSome t -> {
             plugin = plugin
             shouldTransform = st
             transform = t
@@ -105,47 +67,15 @@ type PluginRegistry() =
       | false, _ -> ()
   ]
 
+  let inline GetPluginList<'Cache when PluginCache<'Cache>> () =
+    'Cache.PluginCache.Values |> Seq.toList
 
-[<RequireQualifiedAccess>]
-module PluginRegistry =
-
-  type GetRunnables<'Registry
-    when 'Registry: (member GetRunnables: string list -> RunnablePlugin list)> =
-    'Registry
-
-  type RegisterPlugin<'Registry
-    when 'Registry: (member TryRegister: PluginInfo -> bool)> = 'Registry
-
-  type FromText<'SessionManager
-    when 'SessionManager: (member LoadFromText:
-      string * string * CancellationToken option -> PluginInfo voption)> =
-    'SessionManager
-
-  let inline ofTextCancellable<'PluginRegistry, 'SessionManager
-    when RegisterPlugin<'PluginRegistry> and FromText<'SessionManager>>
-    (registry: 'PluginRegistry, sessionManager: 'SessionManager)
-    (id: string, content: string, token: CancellationToken option)
+  let inline RunPlugins<'Cache when PluginCache<'Cache>>
+    (pluginOrder: string list)
+    fileInput
     =
-    voption {
-      let! plugin = sessionManager.LoadFromText(id, content, token)
-
-      match registry.TryRegister(plugin) with
-      | true -> return plugin
-      | false -> return! ValueNone
-    }
-
-  let inline ofText
-    (registry: 'PluginRegistry, sessionManager: 'SessionManager)
-    (id, content)
-    =
-    ofTextCancellable (registry, sessionManager) (id, content, None)
-
-  let inline runPlugins<'PluginRegistry when GetRunnables<'PluginRegistry>>
-    (registry: 'PluginRegistry)
-    (pluginOrder, fileInput)
-    =
-    cancellableTask {
-      let plugins = registry.GetRunnables pluginOrder
+    async {
+      let plugins = GetRunnablePlugins<'Cache> pluginOrder
 
       let inline folder result next =
         cancellableValueTask {
@@ -156,4 +86,61 @@ module PluginRegistry =
         |> Async.AwaitCancellableValueTask
 
       return! plugins |> AsyncSeq.ofSeq |> AsyncSeq.foldAsync folder fileInput
+    }
+
+  let inline HasPluginsForExtension<'Cache when PluginCache<'Cache>> extension =
+
+    GetPluginList<'Cache>()
+    |> List.exists (fun plugin ->
+      match plugin.shouldProcessFile with
+      | ValueSome f -> f extension
+      | _ -> false)
+
+[<Class; Sealed>]
+type PluginRegistry =
+
+  static member inline LoadFromText<'Cache, 'Writer
+    when PluginCache<'Cache> and SessionCache<'Cache> and StdoutStderr<'Writer>>
+    (
+      id,
+      content,
+      cancellationToken
+    ) =
+    result {
+      let mutable discard: FsiEvaluationSession = Unchecked.defaultof<_>
+      let sessionCache = 'Cache.SessionCache
+
+      do!
+        sessionCache.TryGetValue(id, &discard)
+        |> Result.requireFalse SessionExists
+
+      let plugins = 'Cache.PluginCache
+
+      let session = SessionFactory.create 'Writer.Stdout 'Writer.Stderr
+
+      let evaluation, _ =
+        session.EvalInteractionNonThrowing(
+          content,
+          ?cancellationToken = cancellationToken
+        )
+
+      let! foundValue = result {
+        let! result =
+          evaluation |> Result.ofChoice |> Result.mapError EvaluationFailed
+
+        match result with
+        | Some result -> return result
+        | None ->
+          return!
+            ScriptReflection.findPlugin session
+            |> Result.requireSome BoundValueMissing
+      }
+
+      if foundValue.ReflectionType = typeof<PluginInfo> then
+        sessionCache.Add(id, session)
+        let plugin: PluginInfo = unbox foundValue.ReflectionValue
+        plugins.Add(id, plugin)
+        return plugin
+      else
+        return! Error(NoPluginFound id)
     }

--- a/src/Perla.Plugins/Registry.fsi
+++ b/src/Perla.Plugins/Registry.fsi
@@ -6,8 +6,6 @@ open System.Threading
 
 open FSharp.Compiler.Interactive.Shell
 
-open IcedTasks
-
 open Perla.Plugins
 
 [<Struct>]

--- a/src/Perla.Plugins/Registry.fsi
+++ b/src/Perla.Plugins/Registry.fsi
@@ -14,16 +14,18 @@ open Perla.Plugins
 type PluginLoadError =
   | SessionExists
   | BoundValueMissing
+  | AlreadyLoaded of string
   | EvaluationFailed of evalFailure: exn
   | NoPluginFound of pluginName: string
 
+
 type SessionCache<'Cache
   when 'Cache: (static member SessionCache:
-    Dictionary<string, FsiEvaluationSession>)> = 'Cache
+    Lazy<Dictionary<string, FsiEvaluationSession>>)> = 'Cache
 
 type PluginCache<'Cache
-  when 'Cache: (static member PluginCache: Dictionary<string, PluginInfo>)> =
-  'Cache
+  when 'Cache: (static member PluginCache: Lazy<Dictionary<string, PluginInfo>>)>
+  = 'Cache
 
 type StdoutStderr<'Writer
   when 'Writer: (static member Stdout: TextWriter)
@@ -43,6 +45,9 @@ module PluginRegistry =
 
   val inline HasPluginsForExtension<'Cache when PluginCache<'Cache>> :
     extension: string -> bool
+
+  val inline LoadFromCode<'Cache when PluginCache<'Cache>> :
+    PluginInfo -> Result<unit, PluginLoadError>
 
 [<Class; Sealed>]
 type PluginRegistry =

--- a/src/Perla/Extensibility.fs
+++ b/src/Perla/Extensibility.fs
@@ -1,171 +1,43 @@
 ﻿namespace Perla.Extensibility
 
 open System
-open System.Collections.Concurrent
-open System.IO
-open System.Runtime.InteropServices
-
+open System.Collections.Generic
 open FSharp.Compiler.Interactive.Shell
-open FSharp.Control
 
 open FsToolkit.ErrorHandling
 
-
-open Perla
 open Perla.Types
-open Perla.FileSystem
-open Perla.Plugins
 open Perla.Esbuild
+
 open Perla.Plugins
-open Perla.Logger
+open Perla.Plugins.Registry
 
+[<Struct>]
+type ExtCache =
+  static member PluginCache = new Dictionary<string, PluginInfo>()
 
-type Fsi =
-  static member GetSession
-    (
-      [<Optional>] ?argv: string seq,
-      [<Optional>] ?stdout,
-      [<Optional>] ?stderr
-    ) =
-    let defaultArgv = [|
-      "fsi.exe"
-      "--optimize+"
-      "--nologo"
-      "--gui-"
-      "--readline-"
-    |]
+  static member SessionCache = new Dictionary<string, FsiEvaluationSession>()
 
-    let argv =
-      match argv with
-      | Some argv -> [| yield! defaultArgv; yield! argv |]
-      | None -> defaultArgv
+[<Struct>]
+type PluginStdio =
 
-    let stdout = defaultArg stdout Console.Out
-    let stderr = defaultArg stderr Console.Error
+  static member Stdout = Console.Out
 
-    let config = FsiEvaluationSession.GetDefaultConfiguration()
+  static member Stderr = Console.Error
 
-    FsiEvaluationSession.Create(
-      config,
-      argv,
-      new StringReader(""),
-      stdout,
-      stderr,
-      true
-    )
+module PluginLoader =
+  let inline Load<'Fs, 'Esbuild
+    when 'Fs: (static member PluginFiles: unit -> (string * string) array)
+    and 'Esbuild: (static member GetPlugin: EsbuildConfig -> PluginInfo)>
+    (esbuildConfig: EsbuildConfig)
+    =
+    result {
+      let! plugins =
+        'Fs.PluginFiles()
+        |> Array.Parallel.map (fun (path, content) ->
+          PluginRegistry.LoadFromText<ExtCache, PluginStdio>(path, content))
+        |> List.ofArray
+        |> List.traverseResultM id
 
-
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
-module PluginRegistry =
-
-  let FsiSessions =
-    lazy (ConcurrentDictionary<string, FsiEvaluationSession option>())
-
-  let PluginCache = ConcurrentDictionary<string, PluginInfo>()
-
-  let AddPlugin (plugin: PluginInfo) =
-    match PluginCache.TryAdd(plugin.name, plugin) with
-    | true ->
-      FsiSessions.Value.TryAdd(plugin.name, None) |> ignore
-      Logger.log $"Added %s{plugin.name} to plugin cache"
-    | false -> Logger.log $"Couldn't add %s{plugin.name}"
-
-  let FromText (path: string, content: string) =
-    Logger.log $"Extracting plugin '{path}' from text"
-
-    let Fsi = Fsi.GetSession()
-
-    let evaluation, _ = Fsi.EvalInteractionNonThrowing(content)
-
-    let tryFindBoundValue () =
-      match Fsi.TryFindBoundValue "Plugin", Fsi.TryFindBoundValue "plugin" with
-      | Some bound, _ -> Some bound.Value
-      | None, Some bound -> Some bound.Value
-      | None, None -> None
-
-    let logError ex =
-      Logger.log ($"An error ocurrer while processing {path}", ex)
-
-    let evaluation =
-      evaluation
-      |> Result.ofChoice
-      |> Result.teeError logError
-      |> Result.toOption
-      |> Option.defaultWith tryFindBoundValue
-
-    match evaluation with
-    | Some value when value.ReflectionType = typeof<PluginInfo> ->
-      let plugin = unbox value.ReflectionValue
-
-      match PluginCache.TryAdd(plugin.name, plugin) with
-      | true -> Logger.log $"Added %s{plugin.name} to plugin cache"
-      | false -> Logger.log $"Couldn't add %s{plugin.name}"
-
-      Some plugin
-    | _ -> None
-
-  let CachedPlugins () =
-    PluginCache |> Seq.map (fun entry -> entry.Value)
-
-  let TryGetPluginByName name =
-    match PluginCache.TryGetValue name with
-    | true, plugin -> Some plugin
-    | false, _ -> None
-
-
-  let PluginList (pluginOrder: string list) =
-    let plugins = [
-      for plugin in pluginOrder do
-        match TryGetPluginByName plugin with
-        | Some plugin -> plugin
-        | None -> ()
-    ]
-
-    let chooser (plugin: PluginInfo) =
-      match plugin.shouldProcessFile, plugin.transform with
-      | ValueSome st, ValueSome t ->
-        Some {
-          plugin = plugin
-          shouldTransform = st
-          transform = t
-        }
-      | _ -> None
-
-    plugins |> Seq.choose chooser
-
-  let LoadPlugins (config: EsbuildConfig) =
-    Esbuild.GetPlugin(config) |> AddPlugin
-
-    for (path, content) in FileSystem.PluginFiles() do
-      FromText(path, content) |> ignore
-
-  let HasPluginsForExtension plugins extension =
-    PluginList plugins
-    |> Seq.exists (fun runnable -> runnable.shouldTransform extension)
-
-  let ApplyPlugins (plugins: string list) (fileInput: FileTransform) =
-    let plugins = PluginList(plugins)
-
-    let folder result next = async {
-      match next.shouldTransform result.extension with
-      | true -> return! (next.transform result).AsTask() |> Async.AwaitTask
-      | false -> return result
+      return 'Esbuild.GetPlugin esbuildConfig :: plugins
     }
-
-    plugins |> AsyncSeq.ofSeq |> AsyncSeq.foldAsync folder fileInput
-
-
-
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
-module Scaffolding =
-  [<Literal>]
-  let ScaffoldConfiguration = "TemplateConfiguration"
-
-  let getConfigurationFromScript content =
-    use session = Fsi.GetSession()
-
-    session.EvalInteractionNonThrowing(content) |> ignore
-
-    match session.TryFindBoundValue ScaffoldConfiguration with
-    | Some bound -> Some bound.Value.ReflectionValue
-    | None -> None

--- a/src/Perla/Extensibility.fsi
+++ b/src/Perla/Extensibility.fsi
@@ -1,26 +1,30 @@
 ﻿namespace Perla.Extensibility
 
+open System.IO
+open System.Collections.Generic
+open FSharp.Compiler.Interactive.Shell
+
 open Perla.Types
 open Perla.Plugins
-open System.IO
-open FSharp.Compiler.Interactive.Shell
-open System.Runtime.InteropServices
+open Perla.Plugins.Registry
 
-[<Class>]
-type Fsi =
-  static member GetSession:
-    [<Optional>] ?argv: string seq *
-    [<Optional>] ?stdout: TextWriter *
-    [<Optional>] ?stderr: TextWriter ->
-      FsiEvaluationSession
+[<Struct>]
+type ExtCache =
+  static member PluginCache: Dictionary<string, PluginInfo>
 
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
-module PluginRegistry =
-  val PluginList: pluginOrder: string list -> seq<RunnablePlugin>
-  val AddPlugin: plugin: PluginInfo -> unit
-  val FromText: path: string * content: string -> PluginInfo option
-  val LoadPlugins: config: EsbuildConfig -> unit
-  val HasPluginsForExtension: plugins: string list -> extension: string -> bool
+  static member SessionCache: Dictionary<string, FsiEvaluationSession>
 
-  val ApplyPlugins:
-    plugins: string list -> fileInput: FileTransform -> Async<FileTransform>
+[<Struct>]
+type PluginStdio =
+
+  static member Stdout: TextWriter
+
+  static member Stderr: TextWriter
+
+[<RequireQualifiedAccess>]
+module PluginLoader =
+
+  val inline Load<'Fs, 'Esbuild
+    when 'Fs: (static member PluginFiles: unit -> (string * string) array)
+    and 'Esbuild: (static member GetPlugin: EsbuildConfig -> PluginInfo)> :
+    esbuildConfig: EsbuildConfig -> Result<PluginInfo list, PluginLoadError>

--- a/src/Perla/Extensibility.fsi
+++ b/src/Perla/Extensibility.fsi
@@ -4,15 +4,17 @@ open System.IO
 open System.Collections.Generic
 open FSharp.Compiler.Interactive.Shell
 
+open FsToolkit.ErrorHandling
+
 open Perla.Types
 open Perla.Plugins
 open Perla.Plugins.Registry
 
 [<Struct>]
 type ExtCache =
-  static member PluginCache: Dictionary<string, PluginInfo>
+  static member PluginCache: Lazy<Dictionary<string, PluginInfo>>
 
-  static member SessionCache: Dictionary<string, FsiEvaluationSession>
+  static member SessionCache: Lazy<Dictionary<string, FsiEvaluationSession>>
 
 [<Struct>]
 type PluginStdio =
@@ -27,4 +29,4 @@ module PluginLoader =
   val inline Load<'Fs, 'Esbuild
     when 'Fs: (static member PluginFiles: unit -> (string * string) array)
     and 'Esbuild: (static member GetPlugin: EsbuildConfig -> PluginInfo)> :
-    esbuildConfig: EsbuildConfig -> Result<PluginInfo list, PluginLoadError>
+    esbuildConfig: EsbuildConfig -> Validation<PluginInfo list, PluginLoadError>

--- a/src/Perla/Handlers.fs
+++ b/src/Perla/Handlers.fs
@@ -844,12 +844,14 @@ module Handlers =
     match PluginLoader.Load<FileSystem, Esbuild>(config.esbuild) with
     | Ok plugins -> Logger.log $"Loaded {plugins.Length} plugins"
     | Error err ->
-      match err with
-      | NoPluginFound name -> Logger.log ($"Plugin {name} not found")
-      | EvaluationFailed(ex) ->
-        Logger.log ($"Failed to evaluate plugin", ex = ex)
-      | SessionExists
-      | BoundValueMissing -> Logger.log "Failed to load plugins"
+      for err in err do
+        match err with
+        | NoPluginFound name -> Logger.log ($"Plugin {name} not found")
+        | EvaluationFailed(ex) ->
+          Logger.log ($"Failed to evaluate plugin", ex = ex)
+        | SessionExists
+        | BoundValueMissing -> Logger.log "Failed to load plugins"
+        | AlreadyLoaded name -> Logger.log ($"Plugin {name} already loaded")
 
     do!
       Logger.spinner (
@@ -997,12 +999,14 @@ module Handlers =
     match PluginLoader.Load<FileSystem, Esbuild>(config.esbuild) with
     | Ok plugins -> Logger.log $"Loaded {plugins.Length} plugins"
     | Error err ->
-      match err with
-      | NoPluginFound name -> Logger.log ($"Plugin {name} not found")
-      | EvaluationFailed(ex) ->
-        Logger.log ($"Failed to evaluate plugin", ex = ex)
-      | SessionExists
-      | BoundValueMissing -> Logger.log "Failed to load plugins"
+      for err in err do
+        match err with
+        | NoPluginFound name -> Logger.log ($"Plugin {name} not found")
+        | EvaluationFailed(ex) ->
+          Logger.log ($"Failed to evaluate plugin", ex = ex)
+        | SessionExists
+        | BoundValueMissing -> Logger.log "Failed to load plugins"
+        | AlreadyLoaded name -> Logger.log ($"Plugin {name} already loaded")
 
     do! VirtualFileSystem.Mount(config)
 
@@ -1104,12 +1108,14 @@ module Handlers =
       match PluginLoader.Load<FileSystem, Esbuild>(config.esbuild) with
       | Ok plugins -> Logger.log $"Loaded {plugins.Length} plugins"
       | Error err ->
-        match err with
-        | NoPluginFound name -> Logger.log ($"Plugin {name} not found")
-        | EvaluationFailed(ex) ->
-          Logger.log ($"Failed to evaluate plugin", ex = ex)
-        | SessionExists
-        | BoundValueMissing -> Logger.log "Failed to load plugins"
+        for err in err do
+          match err with
+          | NoPluginFound name -> Logger.log ($"Plugin {name} not found")
+          | EvaluationFailed(ex) ->
+            Logger.log ($"Failed to evaluate plugin", ex = ex)
+          | SessionExists
+          | BoundValueMissing -> Logger.log "Failed to load plugins"
+          | AlreadyLoaded name -> Logger.log ($"Plugin {name} already loaded")
 
       do! VirtualFileSystem.Mount config
 

--- a/tests/Perla.Plugins.Tests/Perla.Plugins.Tests.fsproj
+++ b/tests/Perla.Plugins.Tests/Perla.Plugins.Tests.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Registry.fs" />
+    <Compile Include="Tests.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Perla.Plugins\Perla.Plugins.fsproj" />
+  </ItemGroup>
+  <Import Project="..\..\.paket\Paket.Restore.targets" />
+</Project>

--- a/tests/Perla.Plugins.Tests/Program.fs
+++ b/tests/Perla.Plugins.Tests/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0

--- a/tests/Perla.Plugins.Tests/Registry.fs
+++ b/tests/Perla.Plugins.Tests/Registry.fs
@@ -1,0 +1,98 @@
+module Perla.Plugins.Tests.Registry
+
+
+open System
+open System.Collections.Generic
+open System.Threading.Tasks
+
+open Xunit
+
+open FSharp.Compiler.Interactive.Shell
+open IcedTasks
+
+open Perla.Plugins
+open Perla.Plugins.Registry
+
+let pluginFactory (amount: int) = [
+  for i in 1..amount do
+    {
+      name = sprintf "test%d" i
+      shouldProcessFile =
+        if i % 2 = 0 then ValueSome(fun _ -> true) else ValueNone
+      transform =
+        ValueSome(fun file ->
+          ValueTask.FromResult(
+            {
+              file with
+                  content = $"--- %i{i}\n%s{file.content}"
+            }
+          ))
+    }
+]
+
+module Runnables =
+  type RunnableContainer =
+    static let plugins =
+      lazy
+        (Dictionary<string, PluginInfo>(
+          [
+            for p in pluginFactory 10 do
+              KeyValuePair(p.name, p)
+          ]
+        ))
+
+    static member PluginCache = plugins
+
+  [<Fact>]
+  let ``GetRunnables should return only those who have a "should process file" function``
+    ()
+    =
+    let runnables =
+      PluginRegistry.GetRunnablePlugins<RunnableContainer>(
+        [
+          "test1"
+          "test2"
+          "test3"
+          "test4"
+          "test5"
+          "test6"
+          "test7"
+          "test8"
+          "test9"
+          "test10"
+        ]
+      )
+
+    Assert.Equal(5, runnables.Length)
+
+  [<Fact>]
+  let ``GetPluginList should bring all of the plugins in cache`` () =
+    let plugins = PluginRegistry.GetPluginList<RunnableContainer>()
+
+    Assert.Equal(10, plugins.Length)
+
+  [<Fact>]
+  let ``LoadFromCode should give error if the plugin is already there`` () =
+    let plugin = PluginRegistry.GetPluginList<RunnableContainer>()[0]
+    let result = PluginRegistry.LoadFromCode<RunnableContainer>(plugin)
+
+    match result with
+    | Error(PluginLoadError.AlreadyLoaded _) -> Assert.True(true)
+    | Error err -> Assert.Fail $"Expected error, but got %A{err}"
+    | Ok() -> Assert.Fail $"Expected error, but got %A{result}"
+
+  [<Fact>]
+  let ``LoadFromCode should be successful if the plugin is not in the cache``
+    ()
+    =
+    let plugin = {
+      name = "test11"
+      shouldProcessFile = ValueNone
+      transform = ValueNone
+    }
+
+    let result = PluginRegistry.LoadFromCode<RunnableContainer>(plugin)
+
+    match result with
+    | Ok() -> Assert.True true
+    | Error result -> Assert.Fail $"Expected success, but got %A{result}"

--- a/tests/Perla.Plugins.Tests/Tests.fs
+++ b/tests/Perla.Plugins.Tests/Tests.fs
@@ -1,0 +1,136 @@
+module Perla.Plugins.Tests.Library
+
+open System
+open System.Threading.Tasks
+
+open Xunit
+
+open IcedTasks
+open Perla.Plugins
+
+[<Fact>]
+let ``"plugin" can be made with a synchronous function`` () = taskUnit {
+  let plugin = plugin "plugin" {
+    with_transform (fun file -> { file with content = "transformed" })
+  }
+
+  let file = { extension = ".txt"; content = "test" }
+
+  Assert.Equal("plugin", plugin.name)
+
+  match plugin.transform with
+  | ValueSome transform ->
+    let! result = transform file
+    Assert.Equal("transformed", result.content)
+  | ValueNone -> Assert.Fail("transform should not be none")
+}
+
+[<Fact>]
+let ``"plugin" can be made with an asynchronous function that returns a task``
+  ()
+  =
+  taskUnit {
+    let plugin = plugin "plugin" {
+      with_transform (fun file -> task {
+        do! Task.Delay(50)
+        return { file with content = "transformed" }
+      })
+    }
+
+    let file = { extension = ".txt"; content = "test" }
+
+    Assert.Equal("plugin", plugin.name)
+
+    match plugin.transform with
+    | ValueSome transform ->
+      let! result = transform file
+      Assert.Equal("transformed", result.content)
+    | ValueNone -> Assert.Fail("transform should not be none")
+  }
+
+[<Fact>]
+let ``"plugin" can be made with an asynchronous function that returns an async``
+  ()
+  =
+  taskUnit {
+    let plugin = plugin "plugin" {
+      with_transform (fun file -> async {
+        do! Async.Sleep(50)
+        return { file with content = "transformed" }
+      })
+    }
+
+    let file = { extension = ".txt"; content = "test" }
+
+    Assert.Equal("plugin", plugin.name)
+
+    match plugin.transform with
+    | ValueSome transform ->
+      let! result = transform file
+      Assert.Equal("transformed", result.content)
+    | ValueNone -> Assert.Fail("transform should not be none")
+  }
+
+[<Fact>]
+let ``"plugin" can be made with an asynchronous function that returns a valuetask``
+  ()
+  =
+  taskUnit {
+    let plugin = plugin "plugin" {
+      with_transform (fun file -> vTask {
+        return { file with content = "transformed" }
+      })
+    }
+
+    let file = { extension = ".txt"; content = "test" }
+
+    Assert.Equal("plugin", plugin.name)
+
+    match plugin.transform with
+    | ValueSome transform ->
+      let! result = transform file
+      Assert.Equal("transformed", result.content)
+    | ValueNone -> Assert.Fail("transform should not be none")
+  }
+
+[<Fact>]
+let ``"plugin" should process a file if the predicate is true`` () =
+  let plugin = plugin "plugin" {
+    should_process_file (fun extension -> extension = ".txt")
+    with_transform (fun file -> { file with content = "transformed" })
+  }
+
+  let file = { extension = ".txt"; content = "test" }
+
+  match plugin.shouldProcessFile with
+  | ValueSome shouldProcessFile ->
+    let result = shouldProcessFile file.extension
+    Assert.True(result)
+  | ValueNone -> Assert.Fail("shouldProcessFile should not be none")
+
+[<Fact>]
+let ``"plugin" should not process a file if the predicate is false`` () =
+  let plugin = plugin "plugin" {
+    should_process_file (fun extension -> extension = ".txt")
+    with_transform (fun file -> { file with content = "transformed" })
+  }
+
+  let file = {
+    extension = ".json"
+    content = "test"
+  }
+
+  match plugin.shouldProcessFile with
+  | ValueSome shouldProcessFile ->
+    file.extension |> shouldProcessFile |> Assert.False
+  | ValueNone -> Assert.Fail("shouldProcessFile should not be none")
+
+[<Fact>]
+let ``"plugin" should not process a file if the predicate is not provided`` () =
+  let plugin = plugin "plugin" {
+    with_transform (fun file -> { file with content = "transformed" })
+  }
+
+  match plugin.shouldProcessFile with
+  | ValueSome _ -> Assert.Fail("shouldProcessFile should not be none")
+  | ValueNone -> Assert.True(true)

--- a/tests/Perla.Plugins.Tests/paket.references
+++ b/tests/Perla.Plugins.Tests/paket.references
@@ -3,3 +3,9 @@ group Plugins
     FSharp.Control.AsyncSeq
     FsToolkit.ErrorHandling
     IcedTasks
+
+group Tests
+    Microsoft.NET.Test.Sdk
+    xunit
+    xunit.runner.visualstudio
+    coverlet.collector

--- a/tests/Perla.Tests/Perla.Tests.fsproj
+++ b/tests/Perla.Tests/Perla.Tests.fsproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Env.fs" />


### PR DESCRIPTION
As part of a slight re-design effort I have in mind for some parts of the codebase (apply a bunch of SRTP and maybe static abstract member in interfaces) to ease up the coupling some modules have to their inner value closures.

This should make it easier to swap certain parts of the implementation if not just the important values that allow to fake some implementations, the rest of the functionality should not be affected