### PR TITLE
Fixed `helpActionAsync` (requires Input.context)

### DIFF
--- a/src/Perla/Program.fs
+++ b/src/Perla/Program.fs
@@ -1,4 +1,4 @@
-﻿// Learn more about F# at http://docs.microsoft.com/dotnet/fsharp
+// Learn more about F# at http://docs.microsoft.com/dotnet/fsharp
 
 open Microsoft.Extensions.Logging
 open FSharp.SystemCommandLine
@@ -65,7 +65,8 @@ let main argv =
       // don't replace leading @ strings e.g. @lit-labs/task
       cfg.ResponseFileTokenReplacer <- null)
 
-    noActionAsync
+    inputs Input.context
+    helpActionAsync
 
     addCommands [
       Commands.NewProject appContainer
@@ -79,8 +80,6 @@ let main argv =
       Commands.Template appContainer
       Commands.Describe appContainer
     ]
-
-    helpActionAsync
   }
   |> Async.AwaitTask
   |> Async.RunSynchronously


### PR DESCRIPTION
I made a few adjustments:
* Removed `noActionAsync` since you want to show help as the root action.
* Added `Input.context` since that is the required input for the `helpActionAsync` help action. (I did try to configure it so that choosing `helpAction` or `helpActionAsync` would automatically set the input, but I haven't been able to find a way to make it work, so you just have to do it manually.)
